### PR TITLE
Use baseUrl in scripts to and remove reference to xi service url

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,11 +1,7 @@
 {
-  "baseUrl": "https://staging.trade-tariff.service.gov.uk",
   "services": {
-    "xi": "https://staging.trade-tariff.service.gov.uk/xi/",
-    "dutycal" : "https://staging.trade-tariff.service.gov.uk/duty-calculator",
+    "dutycal" : "https://dev.trade-tariff.service.gov.uk/duty-calculator",
     "docker": "http://localhost:3000/duty-calculator"
-    
-    
   },
   
   "commcodes": [

--- a/cypress/integration/SwitchingLinks-XI/SwitchingLinks-XI.js
+++ b/cypress/integration/SwitchingLinks-XI/SwitchingLinks-XI.js
@@ -1,6 +1,5 @@
-Cypress.config('baseUrl', Cypress.config('services')['xi'])
 Given('I am on XI Trade Tariff main page',()=>{
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
         cy.get('.tariff-breadcrumbs')

--- a/cypress/integration/UK/FE/newTerminatedCommCodes-UK.spec.js
+++ b/cypress/integration/UK/FE/newTerminatedCommCodes-UK.spec.js
@@ -8,7 +8,7 @@ describe(' 🇬🇧 💡 | newTerminatedCommCodes-UK | New ,Terminated comm code
 
         for (let i = 0; i < termcodes_ids.length; i++) {
 
-            cy.visit('/sections')
+            cy.visit('/xi/sections')
             cy.get('.js-commodity-picker-select.js-show  input#q').click().type(`${termcodes_ids[i]}`)
             cy.wait(700)
             cy.get('input[name=\'new_search\']').click()
@@ -21,7 +21,7 @@ describe(' 🇬🇧 💡 | newTerminatedCommCodes-UK | New ,Terminated comm code
         let newcodes_ids = Cypress.config('newcodes');
 
         for (let i = 0; i < newcodes_ids.length; i++) {
-            cy.visit('/sections')
+            cy.visit('/xi/sections')
             cy.get('.js-commodity-picker-select.js-show  input#q').click().type(`${newcodes_ids[i]}`)
             cy.wait(750)
             cy.get('input[name=\'new_search\']').click()

--- a/cypress/integration/XI/API/V2/compareSectionsV2api-XI.spec.js
+++ b/cypress/integration/XI/API/V2/compareSectionsV2api-XI.spec.js
@@ -1,12 +1,11 @@
 
 let data = require('../../../../Data/sections.json');
 // let data = JSON.parse(rawdata);
-Cypress.config('baseUrl', Cypress.config('services')['xi'])
 context('Session: Fetch a Session, given the ID.', () => {
     it('Get sessions by ID - 200', () => {
         cy.request({
             method: 'GET',
-            url: `/api/v2/sections`,
+            url: `/xi/api/v2/sections`,
         }).then((response) => {
             expect(response.status).to.eq(200);
             expect(response.body.data[0]).to.deep.equal({

--- a/cypress/integration/XI/API/V2/quotasPRV2api-XI.spec.js
+++ b/cypress/integration/XI/API/V2/quotasPRV2api-XI.spec.js
@@ -1,10 +1,8 @@
 describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function() {
 
     //----------------Quotas to be suppressed for XI -------------
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('1.Quotas:046 Tariff quota/ceiling -   suppressed ', function () {
-        cy.request('/api/v2/commodities/6301909021#import.json')
+        cy.request('/xi/api/v2/commodities/6301909021#import.json')
             .then((response) => {
                 let measure_types = response.body.included
                 let found = false
@@ -18,7 +16,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
             })
     })
     it('2.Quotas:122-Non Preferential quota -   suppressed ', function () {
-        cy.request('/api/v2/commodities/1006209600#import.json')
+        cy.request('/xi/api/v2/commodities/1006209600#import.json')
             .then((response) => {
                 let measure_types = response.body.included
                 let found = false
@@ -32,7 +30,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
             })
     })
     it('3.Quotas:123 - Non preferential quota under end use -   suppressed ', function () {
-        cy.request('/api/v2/commodities/1701131000#import.json')
+        cy.request('/xi/api/v2/commodities/1701131000#import.json')
             .then((response) => {
                 let measure_types = response.body.included
                 let found = false
@@ -46,7 +44,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
             })
     })
     it('4.Quotas:143 Preferential tariff quota -   suppressed ', function () {
-        cy.request('/api/v2/commodities/1601009991#import.json')
+        cy.request('/xi/api/v2/commodities/1601009991#import.json')
             .then((response) => {
                 let measure_types = response.body.included
                 let found = false
@@ -60,7 +58,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
             })
     })
     it('5.Quotas:146 Preferential tariff quota under end-use -   suppressed ', function () {
-        cy.request('/api/v2/commodities/0709921000#import.json')
+        cy.request('/xi/api/v2/commodities/0709921000#import.json')
             .then((response) => {
                 let measure_types = response.body.included
                 let found = false
@@ -74,7 +72,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
             })
     })
     it('6.Quotas:147 Customs Union Quota -   suppressed ', function () {
-        cy.request('/api/v2/commodities/1806208012#import.json')
+        cy.request('/xi/api/v2/commodities/1806208012#import.json')
             .then((response) => {
                 let measure_types = response.body.included
                 let found = false
@@ -88,7 +86,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
             })
     })
     it('7.Quotas:653 Security based on representative price, reduced under the benefit of a tariff quota -   suppressed ', function () {
-        cy.request('/api/v2/commodities/1701149000#import.json')
+        cy.request('/xi/api/v2/commodities/1701149000#import.json')
             .then((response) => {
                 let measure_types = response.body.included
                 let found = false
@@ -103,7 +101,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
     })
 // ---------------------------National Prohibitions and restrictions (P&R)---------------------------
     it('1.P&R:AHC - Animal Health Certificate -   suppressed ', function () {
-        cy.request('/api/v2/commodities/6403990510#import.json')
+        cy.request('/xi/api/v2/commodities/6403990510#import.json')
             .then((response) => {
                 let measure_types = response.body.included
                 let found = false
@@ -118,7 +116,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
 
     })
     it('2.P&R:AIL - Health and Safety Executive Import Licensing Firearms and Ammunition -   suppressed ', function () {
-        cy.request('/api/v2/commodities/9305200010#import.json').then((response) => {
+        cy.request('/xi/api/v2/commodities/9305200010#import.json').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -133,7 +131,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
 
     })
     it('3.P&R:ATT - Attestation Document (horticulture and potatoes -   suppressed )', function () {
-        cy.request('/api/v2/commodities/1210209099#import.json').then((response) => {
+        cy.request('/xi/api/v2/commodities/1210209099#import.json').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -149,7 +147,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
     })
     //exports
     it('4.P&R:CEX - DCMS Open General Export Licence -   suppressed ', function () {
-        cy.request('/api/v2/commodities/9702000010#export').then((response) => {
+        cy.request('/xi/api/v2/commodities/9702000010#export').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -165,7 +163,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
     })
     //exports
     it('6.P&R:COE - Home Office Controlled Drugs (export) -   suppressed ', function () {
-        cy.request('/api/v2/commodities/2934910000#export').then((response) => {
+        cy.request('/xi/api/v2/commodities/2934910000#export').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -179,7 +177,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
 
     })
     it('7.P&R:COI HMI Conformity Certificate (fruit and veg) issued in UK -   suppressed ', function () {
-        cy.request('/api/v2/commodities/0806101090#import.json').then((response) => {
+        cy.request('/xi/api/v2/commodities/0806101090#import.json').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -194,7 +192,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
 
     })
     it('8.P&R:CVD - Common Veterinary Entry Document (CVED) -   suppressed ', function () {
-        cy.request('/api/v2/commodities/1605531090#import.json').then((response) => {
+        cy.request('/xi/api/v2/commodities/1605531090#import.json').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -210,7 +208,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
     })
     //export
     it('12.P&R:EQC Certificate of Conformity -   suppressed ', function () {
-        cy.request('/api/v2/commodities/0709939000#export').then((response) => {
+        cy.request('/xi/api/v2/commodities/0709939000#export').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -226,7 +224,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
     })
     //export
     it('14.P&R:HOP Home Office pre-cursor chemical authorisation -   suppressed ', function () {
-        cy.request('/api/v2/commodities/2932940000#export').then((response) => {
+        cy.request('/xi/api/v2/commodities/2932940000#export').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -242,7 +240,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
     })
 
     it('15.P&R:HSE Health and Safety Executive (imports) -   suppressed ', function () {
-        cy.request('/api/v2/commodities/3102309000#import.json').then((response) => {
+        cy.request('/xi/api/v2/commodities/3102309000#import.json').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -257,7 +255,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
 
     })
     it('17.P&R:PHC-Phytosanitary Certificate (import) -   suppressed ', function () {
-        cy.request('/api/v2/commodities/0809290000#import.json').then((response) => {
+        cy.request('/xi/api/v2/commodities/0809290000#import.json').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -273,7 +271,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
     })
     //export
     it.skip('18.P&R:PRE Home Office Pre-cursor chemicals -   suppressed ', function () {
-        cy.request('/api/v2/commodities/2915240000#export').then((response) => {
+        cy.request('/xi/api/v2/commodities/2915240000#export').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -288,7 +286,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
 
     })
     it('19.P&R:PRT Home Office Controlled Drugs (import) -   suppressed ', function () {
-        cy.request('/api/v2/commodities/1211500000#import.json').then((response) => {
+        cy.request('/xi/api/v2/commodities/1211500000#import.json').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {
@@ -303,7 +301,7 @@ describe('🇪🇺 ⚙️ XI-version v2 api Quotas , P&R suppression',function()
 
     })
     it('20.P&R:QRC Quarantine Release Certificate -   suppressed ', function () {
-        cy.request('/api/v2/commodities/4403219090#import.json').then((response) => {
+        cy.request('/xi/api/v2/commodities/4403219090#import.json').then((response) => {
             let measure_types = response.body.included
             let found = false
             for (let i = 0; i < measure_types.length; i++) {

--- a/cypress/integration/XI/API/apiValidationV1V2-XI.spec.js
+++ b/cypress/integration/XI/API/apiValidationV1V2-XI.spec.js
@@ -1,8 +1,7 @@
 describe('🇪🇺 ⚙️ | apiValidationV1V2-XI | XI Basic API checks |', () => {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
     // V2 API
     it('XI - V2 - Should return a valid payload and Schema should match', function () {
-        cy.request('/api/v2/commodities/7202118000').then($response => {
+        cy.request('/xi/api/v2/commodities/7202118000').then($response => {
             expect($response.status).to.eq(200)
 
             cy.task('validateJsonSchema', {
@@ -14,7 +13,7 @@ describe('🇪🇺 ⚙️ | apiValidationV1V2-XI | XI Basic API checks |', () =>
     })
 
     it('XI - V2 - Headers,Status,Length,duration', function () {
-        cy.request('/api/v2/commodities/0805220011').as('comments')
+        cy.request('/xi/api/v2/commodities/0805220011').as('comments')
 
         cy.get('@comments')
             .then((response) => {
@@ -31,7 +30,7 @@ describe('🇪🇺 ⚙️ | apiValidationV1V2-XI | XI Basic API checks |', () =>
             })
     })
     it('XI - V2 - Error codes - 404', function () {
-        cy.request({method: 'GET', url: '/api/v2/commodities/08052200110000', failOnStatusCode: false}).as('comments')
+        cy.request({method: 'GET', url: '/xi/api/v2/commodities/08052200110000', failOnStatusCode: false}).as('comments')
         cy.get('@comments')
             .then((response) => {
                 expect(response.status).to.eq(404)
@@ -39,7 +38,7 @@ describe('🇪🇺 ⚙️ | apiValidationV1V2-XI | XI Basic API checks |', () =>
     })
     // V1 API
     it('XI - V1 - Should return a valid payload and Schema should match', function () {
-        cy.request('/api/v1/commodities/7202118000').then($response => {
+        cy.request('/xi/api/v1/commodities/7202118000').then($response => {
             expect($response.status).to.eq(200)
 
             cy.task('validateJsonSchema', {
@@ -51,7 +50,7 @@ describe('🇪🇺 ⚙️ | apiValidationV1V2-XI | XI Basic API checks |', () =>
     })
 
     it('XI - V1 - Headers,Status,Length,duration', function () {
-        cy.request('/api/v1/commodities/0805220011').as('comments')
+        cy.request('/xi/api/v1/commodities/0805220011').as('comments')
 
         cy.get('@comments')
             .then((response) => {
@@ -68,7 +67,7 @@ describe('🇪🇺 ⚙️ | apiValidationV1V2-XI | XI Basic API checks |', () =>
             })
     })
     it('XI - V1 - Error codes - 404', function () {
-        cy.request({method: 'GET', url: '/api/v1/commodities/08052200110000', failOnStatusCode: false}).as('comments')
+        cy.request({method: 'GET', url: '/xi/api/v1/commodities/08052200110000', failOnStatusCode: false}).as('comments')
         cy.get('@comments')
             .then((response) => {
                 expect(response.status).to.eq(404)

--- a/cypress/integration/XI/API/btiUrlAPI-XI.spec.js
+++ b/cypress/integration/XI/API/btiUrlAPI-XI.spec.js
@@ -1,10 +1,8 @@
-Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
 context('🇪🇺 ⚙️ XI - Update bti URL on V1 and V2 ', () => {
     it('XI - Validate API response for V2', () => {
         cy.request({
             method: 'GET',
-            url: '/api/v2/commodities/0202201011'
+            url: '/xi/api/v2/commodities/0202201011'
         }).then((response) => {
             expect(response.status).to.eq(200);
      //       console.log(JSON.stringify(response.body))
@@ -17,7 +15,7 @@ context('🇪🇺 ⚙️ XI - Update bti URL on V1 and V2 ', () => {
     it('XI - Validate API response for V1', () => {
         cy.request({
             method: 'GET',
-            url: '/api/v1/commodities/0202201011'
+            url: '/xi/api/v1/commodities/0202201011'
         }).then((response) => {
             expect(response.status).to.eq(200);
             console.log(JSON.stringify(response.body))

--- a/cypress/integration/XI/API/commcodesAPIvalidation-XI.spec.js
+++ b/cypress/integration/XI/API/commcodesAPIvalidation-XI.spec.js
@@ -1,5 +1,3 @@
-Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
 context('🇪🇺 ⚙️ XI -Validate API response for commodities on V1 and V2 ', () => {
     it.skip('XI - Validate API response for V2', () => {
         let fixture_timestamp = Cypress.config('fixtures_timestamp');
@@ -9,7 +7,7 @@ context('🇪🇺 ⚙️ XI -Validate API response for commodities on V1 and V2 
             cy.readFile(`cypress/Data/xi/v2/${commodity_ids[i]}-${fixture_timestamp}.json`).then((fixture) => {
                 cy.request({
                     method: 'GET',
-                    url: `/api/v2/commodities/${commodity_ids[i]}`
+                    url: `/xi/api/v2/commodities/${commodity_ids[i]}`
                 }).then((response) => {
                     expect(response.status).to.eq(200);
               //      console.log(JSON.stringify(fixture))

--- a/cypress/integration/XI/API/countriesApi-XI.spec.js
+++ b/cypress/integration/XI/API/countriesApi-XI.spec.js
@@ -1,10 +1,7 @@
 describe.skip('🇪🇺 | countriesApi-XI | XI Country Selection |',function() {
-
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('XI - Should return a valid payload and Schema should match', function () {
         cy.readFile(`./cypress/Data/xi/countriesXI.json`).then((fixturexi) => {
-        cy.request('/geographical_areas.json').then($response => {
+        cy.request('/xi/geographical_areas.json').then($response => {
             console.log(JSON.stringify(fixturexi))
             console.log(JSON.stringify($response.body))
             expect($response.status).to.eq(200)

--- a/cypress/integration/XI/FE/Test1-XI.spec.js
+++ b/cypress/integration/XI/FE/Test1-XI.spec.js
@@ -1,15 +1,12 @@
 describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality on XI services ',function() {
-
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('🚀 XI - Routing - Correct page + Legal base does not exist', function () {
-        cy.visit('/commodities/0101210000#import')
+        cy.visit('/xi/commodities/0101210000#import')
         cy.contains('The Northern Ireland (EU) Tariff')
         cy.get('.govuk-tabs__panel')
         cy.contains('Legal base').should('not.exist')
     })
     it('🚀 XI - Header Section-Sub sections ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.title().should('eq', 'The Northern Ireland (EU) Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK')
         cy.get('.govuk-header ')
         cy.contains('Northern Ireland (EU) Tariff')
@@ -25,14 +22,14 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
         cy.contains('Forum').should('not.exist')
     })
     it('🚀 XI - Remove the link to the EU website for looking up measures, geographical areas and regulations - Main Page ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer')
         cy.contains('API Documentation')
         cy.contains('Integrated tariff of the European Community (TARIC) database').should('not.exist')
 
     })
     it('🚀 XI - Sections Page - Switching link to UK available & works', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header ')
             .contains('Northern Ireland (EU) Tariff')
         //check correct text is displayed on banner
@@ -53,7 +50,7 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
             .contains('Online Tariff')
     })
     it('🚀 XI - Sections Page - Guidance Link and Page link', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         // Guidance link on XI page
         cy.get('.govuk-main-wrapper')
             .contains('if your goods are not ‘at risk’ of onward movement to the EU').click()
@@ -67,7 +64,7 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
             .contains('Northern Ireland (EU) Tariff')
     })
     it('🚀 XI - Change to future date and check if the data shown is same for both XI and UK', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.js-show.sections-context.text > a[role=\'button\']').click()
         cy.get('input#tariff_date_date')
             .clear()
@@ -92,14 +89,14 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
     })
 
     it('🚀 XI - Change Currency should not be visible on main page - The Northern Ireland (EU) Tariff for the XI', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-grid-row')
         cy.contains('Change date')
         cy.contains('Change currency').should('not.exist')
     })
 
     it('🚀 United Kingdom should NOT be shown in EU country list', function () {
-        cy.visit('/commodities/2403991000?day=3&month=1&year=2021#import')
+        cy.visit('/xi/commodities/2403991000?day=3&month=1&year=2021#import')
         cy.get('.govuk-tabs__panel')
         cy.contains('European Economic Area (2012)')
             .click()
@@ -112,7 +109,7 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
     })
 
     it('🚀 XI Switching link banner on sections page for Jan 1 2021', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         //check header has Xi information
         cy.get('.govuk-header ')
             .contains('Northern Ireland (EU) Tariff')
@@ -146,7 +143,7 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
 
     })
     it('🚀Enter commodity code for Mozzaarella - Sections page and search',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-label')
             .contains('Search the Northern Ireland tariff for \'at risk\' goods')
         cy.get('.js-commodity-picker-select.js-show  input#q').click().type('0406103010')
@@ -157,7 +154,7 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
             .contains('Commodity information for 0406103010')
     })
     it('🚀 Enter commodity code for Mozzaarella - Sections/selecting chapter number and search',function(){
-        cy.visit('/sections/4')
+        cy.visit('/xi/sections/4')
         cy.get('.govuk-label')
             .contains('Search the Northern Ireland tariff for \'at risk\' goods')
         cy.get('.js-commodity-picker-select.js-show  input#q').click().type('0406103010')
@@ -168,7 +165,7 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
             .contains('Commodity information for 0406103010')
     })
     it('🚀 Enter commodity code for Mozzaarella - Chapters and search',function(){
-        cy.visit('chapters/20')
+        cy.visit('/xichapters/20')
         cy.get('.govuk-label')
             .contains('Search the Northern Ireland tariff for \'at risk\' goods')
         cy.get('.js-commodity-picker-select.js-show  input#q').click().type('0406103010')
@@ -179,7 +176,7 @@ describe.skip('🚀 XI 🇪🇺 💡  - Smoke test to cover basic functionality 
             .contains('Commodity information for 0406103010')
     })
     it('🚀 Enter commodity code for Mozzaarella - Headings and search',function(){
-        cy.visit('headings/2003')
+        cy.visit('/xiheadings/2003')
         cy.get('.govuk-label')
             .contains('Search the Northern Ireland tariff for \'at risk\' goods')
         cy.get('.js-commodity-picker-select.js-show  input#q').click().type('0406103010')

--- a/cypress/integration/XI/FE/additionalCode-XI.spec.js
+++ b/cypress/integration/XI/FE/additionalCode-XI.spec.js
@@ -1,8 +1,6 @@
 describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it(' XI Additional Code Search : 2 - Tariff preference', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         let tpadcodes_ids = ["2500","2501"]
@@ -23,7 +21,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
         }
     })
     it(' XI Additional Code Search : 3 - Prohibition/Restriction/Surveillance', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         let prsadcodes_ids = ["3000","3002"]
@@ -44,7 +42,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
         }
     })
     it(' XI Additional Code Search : 4 - Restrictions', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         let radcodes_ids = ["4008","4010"]
@@ -66,7 +64,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
     })
 
     it(' XI Additional Code Search : 6 - Agricultural Tables (non-Meursing)', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         //select type of certificate from drop down menu
@@ -81,7 +79,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
     })
 
     it(' XI Additional Code Search : 7 - Agricultural Tables (Meursing)', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         //select type of certificate from drop down menu
@@ -95,7 +93,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
 
     })
     it(' XI Additional Code Search : 8 - Anti-dumping/countervailing', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         let adadcodes_ids = ["8042","8044"]
@@ -117,7 +115,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
     })
 
     it(' XI Additional Code Search : 9 - Export Refunds', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         //select type of certificate from drop down menu
@@ -133,7 +131,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
 
 
     it(' XI Additional Code Search : A - Anti-dumping/countervailing', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         let adcadcodes_ids = ["057","097"]
@@ -156,7 +154,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
 
 
     it(' XI Additional Code Search : B - Anti-dumping/countervailing', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         let badcadcodes_ids = ["001","002"]
@@ -178,7 +176,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
     })
 
     it(' XI Additional Code Search : C - Anti-dumping/countervailing', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         let cadcadcodes_ids = ["046","047"]
@@ -201,7 +199,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
 
 
     it(' XI Additional Code Search : D - Dual Use', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         //select type of certificate from drop down menu
@@ -217,7 +215,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
 
 
     it(' XI Additional Code Search : F - Reference prices fishery products', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         //select type of certificate from drop down menu
@@ -232,7 +230,7 @@ describe('🇪🇺 💡  Additional Code Search -XI services)',function() {
     })
 
     it(' XI Additional Code Search : P - Refund for basic products', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
 
         //select type of certificate from drop down menu

--- a/cypress/integration/XI/FE/certificateSearch-XI.spec.js
+++ b/cypress/integration/XI/FE/certificateSearch-XI.spec.js
@@ -1,8 +1,6 @@
 describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services |',function() {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('XI Certificate Search : 9 - National Document', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
 
         let ndcerts_ids = ["9100", "9103", "9104", "9105"]
@@ -24,7 +22,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : A - Certificate of authenticity', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
 
         let adcerts_ids = ["022", "023", "030", "017"]
@@ -47,7 +45,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : C - Other certificates', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         let ccerts_ids = ["C014", "C015", "C017", "C018", "C052"]
         for (let i = 0; i < ccerts_ids.length; i++) {
@@ -67,7 +65,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : D - Anti-dumping/countervailing document', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         let dcerts_ids = ["D005", "D017"]
         for (let i = 0; i < dcerts_ids.length; i++) {
@@ -88,7 +86,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
 
     })
     it('XI Certificate Search : E - Export certificate/licence/document from country of origin', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         let ecerts_ids = ["012", "013", "990"]
         for (let i = 0; i < ecerts_ids.length; i++) {
@@ -109,7 +107,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : H - HANDI, LOOMS certificate', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         cy.get('select#type').select('H - HANDI, LOOMS certificate')
         cy.wait(500)
@@ -121,7 +119,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : I - Surveillance certificate/licence/ document issued by one of the Member States', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         let icerts_ids = ["004"]
         for (let i = 0; i < icerts_ids.length; i++) {
@@ -141,7 +139,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : K - Tariff quota', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         cy.get('select#type').select('K - Tariff quota')
         cy.wait(500)
@@ -153,7 +151,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : L - Import certificate/licence/document', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
 
         let lcerts_ids = ["L001"]
@@ -176,7 +174,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : N - UN/EDIFACT certificates', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
 
         let ncerts_ids = ["002", "853", "865", "954"]
@@ -199,7 +197,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : P - Ingredients', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         cy.get('select#type').select('P - Ingredients')
         cy.wait(500)
@@ -210,7 +208,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
 
     })
     it('XI Certificate Search : R - Export refunds', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         cy.get('select#type').select('R - Export refunds')
         cy.wait(500)
@@ -221,7 +219,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
 
     })
     it('XI Certificate Search : T - T-Document', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         cy.get('select#type').select('T - T-Document')
         cy.wait(500)
@@ -232,7 +230,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
 
     })
     it('XI Certificate Search : U - Proofs of origin', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
 
         let ucerts_ids = ["004", "059", "062"]
@@ -254,7 +252,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
 
     })
     it('XI Certificate Search : X - Export licence', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
 
         let xcerts_ids = ["X018", "X035"]
@@ -275,7 +273,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : Y - Particular provisions', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
 
         let ycerts_ids = ["Y058", "Y072", "Y073", "Y076", "Y077", "Y078", "Y079", "Y929", "Y930", "Y945", "Y946"]
@@ -299,7 +297,7 @@ describe('🇪🇺 💡 |certificateSearch-XI | Certificate Search - XI services
     })
 
     it('XI Certificate Search : Z - More certificates', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         cy.get('select#type').select('Z - More certificates')
         cy.wait(500)

--- a/cypress/integration/XI/FE/chemicalSearch-XI.spec.js
+++ b/cypress/integration/XI/FE/chemicalSearch-XI.spec.js
@@ -1,8 +1,6 @@
 describe('🇪🇺 💡   Chemical Search 🧪 -  XI services)',function() {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('XI Chemical Search -using CAS number', function () {
-        cy.visit('/chemical_search')
+        cy.visit('/xi/chemical_search')
         cy.contains('Search by Chemical')
         let casno_ids = ["149177-92-4", "249561-98-6", "94-05-3","13338-63-1"]
         for (let i = 0; i < casno_ids.length; i++) {
@@ -19,7 +17,7 @@ describe('🇪🇺 💡   Chemical Search 🧪 -  XI services)',function() {
     })
 
     it('XI Chemical Search -using Chemical Name', function () {
-        cy.visit('/chemical_search')
+        cy.visit('/xi/chemical_search')
         cy.contains('Search by Chemical')
 
         let cname_ids = ["methyl N-(phenoxycarbonyl)-L-valinate","hexafluorophosphate(3-)", "ethyl 3,4-dihydroxybenzoate", "dimethyl cyanocarbonimidodithioate", "3,4,5-trimethoxyphenylacetonitrile", "6(2Z,3R)-3-O-decyl-2-deoxy-6-O-2-deoxy-3-O-(3-metoxydecyl)-6-methyl-2-(1-oxo-11-octadecenyl)amino-4-O-phosphono-β-D-glucopyranosyl-2-(1,3-dioxotetradecyl)amino-α-D-glucopyranose 1-(dihydrogen phosphate) tetrasodium salt", "(±)-1-azabicyclo2.2.1heptan-3-one"]

--- a/cypress/integration/XI/FE/countrySelection-XI.spec.js
+++ b/cypress/integration/XI/FE/countrySelection-XI.spec.js
@@ -1,8 +1,6 @@
 describe('🇪🇺 💡 |countrySelection-XI | Country Selection - hjid tests |',function() {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('XI Country Selection -import ',function(){
-        cy.visit('/commodities/0208909800#import')
+        cy.visit('/xi/commodities/0208909800#import')
         // XI Present
         cy.get('input#import_search_country').click().clear().wait(500).type('XI').wait(500)
         cy.get("[id='import_search_country__listbox']")
@@ -25,7 +23,7 @@ describe('🇪🇺 💡 |countrySelection-XI | Country Selection - hjid tests |'
 
     })
     it('XI Country Selection -export ',function(){
-        cy.visit('/commodities/0208909800#export')
+        cy.visit('/xi/commodities/0208909800#export')
         // XI Present
         cy.get('input#export_search_country').click().clear().wait(500)
             .type('XI').wait(500)

--- a/cypress/integration/XI/FE/e2eMozzarellaChile-XI.spec.js
+++ b/cypress/integration/XI/FE/e2eMozzarellaChile-XI.spec.js
@@ -1,8 +1,6 @@
 describe('🇪🇺 💡 🧀  | e2eMozarellaChile-XI | importing Mozzarella from Chile |',function() {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('Navigate to trade tariff page ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
             .contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
     
     //Enter commodity code for Mozzaarella - 0406103010 and search',function(){

--- a/cypress/integration/XI/FE/e2eSpecialComms-XI.spec.js
+++ b/cypress/integration/XI/FE/e2eSpecialComms-XI.spec.js
@@ -1,12 +1,10 @@
 describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and measure details |', function () {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('Ferro-alloy \n' + 'Third country duty should be ad valorem 2.7%\n' +
         '\n' +
         'There is a tariff preference of 0.00% against the European Economic Area (2012)\n' +
         '\n' +
         'There are no duties that are expressed in currencies ', function () {
-            cy.visit('/commodities/7202118000#import')
+            cy.visit('/xi/commodities/7202118000#import')
                 .contains('Commodity information for 7202118000')
             cy.get('.govuk-header__content')
                 .contains('Northern Ireland Online Tariff')
@@ -23,7 +21,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
     it(' 🦬 Bison \n Third country duty should be a compound duty of 12.80 % + 176.80 EUR / 100 kg\n' +
         '\n' +
         'Duties are expressed in EUROs', function () {
-            cy.visit('/commodities/0201100021#import')
+            cy.visit('/xi/commodities/0201100021#import')
                 .contains('Commodity information for 0201100021')
             cy.get('.govuk-header__content')
                 .contains('Northern Ireland Online Tariff')
@@ -32,7 +30,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
             cy.contains('12.80 % + 176.80 EUR / 100 kg')
         })
     it('  🔊 Amplifiers\n also has a supplementary unit measure of p/st', function () {
-        cy.visit('/commodities/8518400010#import')
+        cy.visit('/xi/commodities/8518400010#import')
             .contains('Commodity information for 8518400010')
         cy.get('.govuk-header__content')
             .contains('Northern Ireland Online Tariff')
@@ -44,7 +42,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
     it('Ceramic tiles \n has anti-dumping measures for China\n' +
         '\n' +
         'Shown by a bold B999 against a Definitive anti-dumping duty measure', function () {
-            cy.visit('/commodities/6907220000?country=CN#import')
+            cy.visit('/xi/commodities/6907220000?country=CN#import')
             cy.get('.govuk-header__content')
                 .contains('Northern Ireland Online Tariff')
             cy.get('#measure-3600805')
@@ -54,7 +52,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
     it(' 🍪 Sandwich biscuits\n Check that the third country duty contains Meursing-related components, e.g. check for strings EA and ADSZ\n' +
         '\n' +
         '9.00 % + EA MAX 24.20 % +ADSZ', function () {
-            cy.visit('/commodities/1905319100#import')
+            cy.visit('/xi/commodities/1905319100#import')
                 .contains('Commodity information for 1905319100')
             cy.get('.govuk-header__content')
                 .contains('Northern Ireland Online Tariff')
@@ -69,7 +67,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
         '\n' +
         'Check that there are no quotas at all' +
         '\n', function () {
-            cy.visit('/commodities/0702000007#import')
+            cy.visit('/xi/commodities/0702000007#import')
                 .contains('Commodity information for 0702000007')
             cy.get('.govuk-header__content')
                 .contains('Northern Ireland Online Tariff')
@@ -91,7 +89,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
 
 
     it(' 🍻 Beer\n Has multiple excise lines expressed in litres,\n Identical to UK', function () {
-        cy.visit('/commodities/2203001000#import')
+        cy.visit('/xi/commodities/2203001000#import')
             .contains('Commodity information for 2203001000')
         cy.get('.govuk-header__content')
             .contains('Northern Ireland Online Tariff')
@@ -111,7 +109,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
     })
 
     it('Turbines \n Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms', function () {
-        cy.visit('/commodities/8406810000#import')
+        cy.visit('/xi/commodities/8406810000#import')
             .contains('Commodity information for 8406810000')
         cy.get('.govuk-header__content')
             .contains('Northern Ireland Online Tariff')
@@ -126,7 +124,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
     })
 
     it(' 🚬 Cheroots\n EXCISE - FULL, 615, CIGARS duty of 305.32 GBP / kg - same as UK', function () {
-        cy.visit('/commodities/2402100000#import')
+        cy.visit('/xi/commodities/2402100000#import')
             .contains('Commodity information for 2402100000')
         cy.get('.govuk-header__content')
             .contains('Northern Ireland Online Tariff')
@@ -138,7 +136,7 @@ describe('🇪🇺 💡 | e2eSpecialComms-XI.spec | XI - Select Commodities and 
     it(' 🍷 Piquette(type of wine) \n-Has a third country duty of:\n' +
         '\n' +
         '1.30 EUR / % vol / hl MIN 7.20 EUR / hl', function () {
-            cy.visit('/commodities/2206001000#import')
+            cy.visit('/xi/commodities/2206001000#import')
                 .contains('Commodity information for 2206001000')
             cy.get('.govuk-header__content')
                 .contains('Northern Ireland Online Tariff')

--- a/cypress/integration/XI/FE/feedback-XI.spec.js
+++ b/cypress/integration/XI/FE/feedback-XI.spec.js
@@ -1,6 +1,4 @@
 describe.skip('🇪🇺 💡| feedback-XI | feedback link is available and user is able to send feedback)',function() {
-
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
     it('XI - All pages- Feedback link available  ', function () {
 
         let pages = ['/sections/1', '/chapters/01', '/headings/0101','/commodities/0101210000',]
@@ -13,7 +11,7 @@ describe.skip('🇪🇺 💡| feedback-XI | feedback link is available and user 
     })
 
     it('XI - Feedback link works ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__navigation')
         cy.contains('Feedback')
             .click()
@@ -35,7 +33,7 @@ describe.skip('🇪🇺 💡| feedback-XI | feedback link is available and user 
 
     })
     it('XI - The UK has left the EU',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__row')
         cy.contains('The UK has left the EU')
     })

--- a/cypress/integration/XI/FE/legalBaseColumn-XI.spec.js
+++ b/cypress/integration/XI/FE/legalBaseColumn-XI.spec.js
@@ -1,23 +1,20 @@
 describe('🇪🇺 💡 Hide Legal base Column , Binding Tariff information link- (XI version) ',function() {
 //HOT-58 Suppressing Legal Base Column for XI
-
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     // front end
     it('🚫 1.Prove that the legal base column has been removed from the import measures tab on XI - commodity 0101210000', function () {
-        cy.visit('/commodities/0101210000#import')
+        cy.visit('/xi/commodities/0101210000#import')
         cy.get('.govuk-tabs__panel')
         cy.contains('Legal base').should('not.exist')
     })
 
     it('🚫 2.Prove that the legal base column has been removed from the export measures tab on XI - commodity 0101210000', function () {
-        cy.visit('/commodities/0101210000#export')
+        cy.visit('/xi/commodities/0101210000#export')
         cy.wait(500)
         cy.contains('Legal base').should('not.exist')
     })
 
     it('🚫 3.Binding Tariff Information link - not visible',function(){
-        cy.visit('commodities/0102290500')
+        cy.visit('/xi/commodities/0102290500')
         cy.get('.govuk-tabs__panel')
         cy.contains('Binding tariff information').should('not.exist')
     })

--- a/cypress/integration/XI/FE/mainPage-XI.spec.js
+++ b/cypress/integration/XI/FE/mainPage-XI.spec.js
@@ -1,20 +1,18 @@
 describe('🇪🇺 💡 | mainPage-XI | Main Page ,headings ,sections - (XI version) |',function() {
     //--- HOTT-82 -------------
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     //Page Title
     it('Header text - Page- sections - Northern Ireland Online Tariff', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header').should('be.visible', 'Northern Ireland Online Tariff')
     })
     //Gov Logo
     it('Header text - GOV.UK logo ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header').should('be.visible', 'GOV.UK')
     })
     //Sub sections in headings
     it('Header text - Page -sections -Sub sections on headings banner ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header ')
         cy.contains('Search or browse the Tariff')
         cy.contains('A-Z')
@@ -29,7 +27,7 @@ describe('🇪🇺 💡 | mainPage-XI | Main Page ,headings ,sections - (XI vers
     })
 
     it('Sections Page - Forum section removed', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header ')
         cy.contains('Forum').should('not.exist')
     })
@@ -75,18 +73,18 @@ describe('🇪🇺 💡 | mainPage-XI | Main Page ,headings ,sections - (XI vers
         cy.get('.govuk-header').should('be.visible', 'Northern Ireland Online Tariff')
     })
     it('Search the Tariff section',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header').contains('Search or browse the Tariff').click()
         cy.get('.govuk-main-wrapper')
             .contains('Search the Northern Ireland Online Tariff')
     })
     it('A-Z section',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('li:nth-of-type(2) > .govuk-header__link').click()
         cy.contains('A–Z of Classified Goods')
     })
     it('Tools section',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('li:nth-of-type(3) > .govuk-header__link').click()
         cy.contains('Certificate, licenses and documents')
         cy.contains('Additional codes')
@@ -100,27 +98,27 @@ describe('🇪🇺 💡 | mainPage-XI | Main Page ,headings ,sections - (XI vers
 
     //HOTT-164
     it('Remove the link to the EU website for looking up measures, geographical areas and regulations - Main Page ',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer')
         cy.contains('API Documentation')
         cy.contains('Integrated tariff of the European Community (TARIC) database').should('not.exist')
 
     })
     it('Remove the link to the EU website for looking up measures, geographical areas and regulations - Terms and Conditions -page link ',function() {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__inline-list > li:nth-of-type(3) > .govuk-footer__link').click()
         cy.contains('Summary')
         cy.contains('Integrated tariff of the European Community (TARIC) database').should('not.exist')
     })
     it('Remove the link to the EU website for looking up measures, geographical areas and regulations - Terms and Conditions -URL',function(){
-    cy.visit('/terms')
+    cy.visit('/xi/terms')
     cy.contains('Summary')
     cy.get('.govuk-template ')
     cy.contains('Integrated tariff of the European Community (TARIC) database').should('not.exist')
 
     })
     it('XI - Footnotes tab ',function(){
-        cy.visit('/commodities/4101203000')
+        cy.visit('/xi/commodities/4101203000')
      
         cy.contains('TN701').should('not.be.visible')
         //Import Tab

--- a/cypress/integration/XI/FE/newTerminatedCommCodes-XI.spec.js
+++ b/cypress/integration/XI/FE/newTerminatedCommCodes-XI.spec.js
@@ -1,10 +1,8 @@
 describe.skip(' 🇪🇺 💡 New ,Terminated comm codes from 1st Jan 2021',function() {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it.skip('Terminated comm codes from 01 Jan 2021', function () {
         let termcodes_ids = Cypress.config('termcodes');
         for (let i = 0; i < termcodes_ids.length; i++) {
-            cy.visit('/sections')
+            cy.visit('/xi/sections')
             cy.get('.js-commodity-picker-select.js-show  input#q').click().type(`${termcodes_ids[i]}`)
             cy.wait(500)
             cy.get('input[name=\'new_search\']').click()
@@ -14,10 +12,9 @@ describe.skip(' 🇪🇺 💡 New ,Terminated comm codes from 1st Jan 2021',func
     })
 
     it('New comm codes starting from 01 Jan 2021', function () {
-
         let newcodes_ids = Cypress.config('newcodes');
         for (let i = 0; i < newcodes_ids.length; i++) {
-            cy.visit('/sections')
+            cy.visit('/xi/sections')
             cy.get('.js-commodity-picker-select.js-show  input#q').click().type(`${newcodes_ids[i]}`)
             cy.wait(700)
             cy.get('input[name=\'new_search\']').click()

--- a/cypress/integration/XI/FE/pageLinks-XI.spec.js
+++ b/cypress/integration/XI/FE/pageLinks-XI.spec.js
@@ -1,9 +1,7 @@
 describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Privacy links - XI ',function() {
 //  HOTT-192
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('XI - Terms and Conditions-navigates to right UK page ',function() {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__inline-list > li:nth-of-type(3) > .govuk-footer__link')
             .contains('Terms and conditions').click()
         cy.title().should('eq', 'Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates - GOV.UK')
@@ -12,7 +10,7 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
     })
 
     it('XI - Cookies -navigates to right XI page',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__inline-list > li:nth-of-type(2) > .govuk-footer__link')
             .contains('Cookies').click()
         cy.title().should('eq','Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates - GOV.UK')
@@ -24,7 +22,7 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
 
     })
     it('XI - Privacy-navigates to right XI page ',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__inline-list > li:nth-of-type(1) > .govuk-footer__link')
             .contains('Privacy').click()
         cy.contains('Privacy notice')
@@ -35,7 +33,7 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
     })
     //HOTT-166
     it.skip('XI - List of supplementary units and their descriptions in imports to be HIDDEN',function(){
-        cy.visit('/commodities/9702000010?currency=EUR#import')
+        cy.visit('/xi/commodities/9702000010?currency=EUR#import')
         cy.get('.govuk-tabs__panel')
             .contains('What are the main types of tariffs and charges').click()
         cy.get('span#details-import-supplementary-unit-heading')
@@ -44,7 +42,7 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
 
     })
     it('XI - List of supplementary units and their descriptions in exports to be HIDDEN',function(){
-        cy.visit('/commodities/9702000010?currency=EUR#export')
+        cy.visit('/xi/commodities/9702000010?currency=EUR#export')
         cy.get('span#details-export-heading')
             .contains('What are the main types of tariffs and charges').click()
         cy.get('span#details-export-supplementary-unit-heading')
@@ -54,7 +52,7 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
 
     })
     it('XI- Links to Previous and Next Commodity - available',function(){
-        cy.visit('/commodities/2801200000')
+        cy.visit('/xi/commodities/2801200000')
         //page contains commodity information
         cy.contains('Commodity information for 2801200000')
         //validate page has previous and next commodity links with commodity name at the bottom
@@ -82,7 +80,7 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
 
     //The UK has left the EU
     it('XI - The UK has left the EU - Check the new rules for January 2021 ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.contains('The UK has left the EU')
         cy.contains('Check the new rules for January 2021')
         cy.get('.govuk-footer__navigation .govuk-footer__row:nth-of-type(1) [target]').should('have.attr', 'href', 'https://www.gov.uk/transition') // no page load!
@@ -90,21 +88,21 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
     })
 
     it('XI - Contact - Ask HMRC for advice on classifying your goods', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('Ask HMRC for advice on classifying your goods')
         cy.get('.govuk-\\!-margin-top-5.govuk-footer__row > div:nth-of-type(1) > .govuk-footer__list > li:nth-of-type(1) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods') // no page load!
 
     })
     it('XI - Contact - Imports and exports: general enquiries', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('Imports and exports: general enquiries')
         cy.get('.govuk-\\!-margin-top-5.govuk-footer__row > div:nth-of-type(1) > .govuk-footer__list > li:nth-of-type(2) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries') // no page load!
 
     })
     it('XI - Contact - Feedback', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('Feedback')
         cy.get('.govuk-\\!-margin-top-5.govuk-footer__row > div:nth-of-type(1) > .govuk-footer__list > li:nth-of-type(3) > .govuk-footer__link').should('have.attr', 'href', '/xi/feedback')
@@ -113,19 +111,19 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
     //Help Section
 
     it('XI - Help - Finding commodity codes for imports or exports',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('Finding commodity codes for imports or exports')
         cy.get('div:nth-of-type(2) > .govuk-footer__list > li:nth-of-type(1) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/guidance/finding-commodity-codes-for-imports-or-exports')
     })
     it('XI - Help - Using the Trade Tariff tool to find a commodity code',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('Using the Trade Tariff tool to find a commodity code')
         cy.get('div:nth-of-type(2) > .govuk-footer__list > li:nth-of-type(2) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/guidance/using-the-trade-tariff-tool-to-find-a-commodity-code')
     })
     it('XI - Help - Import and export',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('Import and export')
         cy.get('div:nth-of-type(2) > .govuk-footer__list > li:nth-of-type(3) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/topic/business-tax/import-export')
@@ -134,21 +132,21 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
 
     //Related information
     it('XI - Related information - UK Trade Tariff: Volume 1 – background information for importers and exporters',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('UK Trade Tariff: Volume 1 – background information for importers and exporters')
         cy.get('div:nth-of-type(3) > .govuk-footer__list > li:nth-of-type(1) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/government/collections/uk-trade-tariff-volume-1')
     })
 
     it('XI - Related information - UK Trade Tariff: Volume 3 – procedures, codes and declaration entry details',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('UK Trade Tariff: Volume 1 – background information for importers and exporters')
         cy.get('div:nth-of-type(3) > .govuk-footer__list > li:nth-of-type(2) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/government/collections/uk-trade-tariff-volume-3')
     })
 
     it('XI - Related information - API Documentation',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__list')
         cy.contains('API Documentation')
         cy.get('div:nth-of-type(3) > .govuk-footer__list > li:nth-of-type(3) > .govuk-footer__link').should('have.attr', 'href', 'https://api.trade-tariff.service.gov.uk/#gov-uk-trade-tariff-api')
@@ -157,7 +155,7 @@ describe(' 🇪🇺 💡 |pageLinks-XI.spec| Terms and Conditions, Cookies ,Priv
     // OGL link
 
     it('XI - Open Government Licence v3.0',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-footer__meta.govuk-footer__row')
         cy.contains('Open Government Licence v3.0')
         cy.get('span > .govuk-footer__link').should('have.attr', 'href', 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/')

--- a/cypress/integration/XI/FE/quotas-PR-XI.spec.js
+++ b/cypress/integration/XI/FE/quotas-PR-XI.spec.js
@@ -1,110 +1,108 @@
 describe('🇪🇺 💡 Quotas to be suppressed for XI version ,P&R to be available',function() {
 
     //----------------Quotas to be suppressed for XI -------------
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('🚫 1.Quotas:046 Tariff quota/ceiling', function () {
         cy.clearCookies();
-        cy.visit('/commodities/6301909021#import')
+        cy.visit('/xi/commodities/6301909021#import')
         //   cy.get('.govuk-tabs__panel').should('not.have.value', 'quota')
         cy.get('.govuk-tabs__panel')
         cy.contains('quota').should('not.exist')
     })
     it('🚫 2.Quotas:122-Non Preferential quota', function () {
-        cy.visit('/commodities/1006209600#import')
+        cy.visit('/xi/commodities/1006209600#import')
         cy.get('.govuk-tabs__panel')
         cy.contains('quota').should('not.exist')
     })
     it('🚫 3.Quotas:123 - Non preferential quota under end use', function () {
-        cy.visit('/commodities/1701131000#import')
+        cy.visit('/xi/commodities/1701131000#import')
         cy.get('.govuk-tabs__panel')
         cy.contains('quota').should('not.exist')
     })
     it('🚫 4.Quotas:143 Preferential tariff quota', function () {
-        cy.visit('/commodities/1601009991#import')
+        cy.visit('/xi/commodities/1601009991#import')
         cy.get('.govuk-tabs__panel')
         cy.contains('quota').should('not.exist')
     })
     it('🚫 5.Quotas:146 Preferential tariff quota under end-use', function () {
-        cy.visit('/commodities/0709921000#import')
+        cy.visit('/xi/commodities/0709921000#import')
         cy.get('.govuk-tabs__panel')
         cy.contains('quota').should('not.exist')
     })
     it('🚫 6.Quotas:147 Customs Union Quota', function () {
-        cy.visit('/commodities/1806208012#import')
+        cy.visit('/xi/commodities/1806208012#import')
         cy.get('.govuk-tabs__panel')
         cy.contains('quota').should('not.exist')
     })
     it('🚫 7.Quotas:653 Security based on representative price, reduced under the benefit of a tariff quota', function () {
-        cy.visit('/commodities/1701149000#import')
+        cy.visit('/xi/commodities/1701149000#import')
         cy.get('.govuk-tabs__panel')
         cy.contains('quota').should('not.exist')
     })
     // ---------------------------National Prohibitions and restrictions (P&R)---------------------------
     it('✅ 1.P&R:AHC - Animal Health Certificate', function () {
-        cy.visit('/commodities/6403990510#import')
+        cy.visit('/xi/commodities/6403990510#import')
         cy.contains('Animal Health Certificate')
         cy.get('#measure-20087633').contains('Conditions').click()
         cy.contains('Animal Health Certificate for All countries')
     })
     it('✅  2.P&R:AIL - Health and Safety Executive Import Licensing Firearms and Ammunition', function () {
-        cy.visit('/commodities/9305200010#import')
+        cy.visit('/xi/commodities/9305200010#import')
         cy.get('#measure-20088554').contains('Conditions').click()
         cy.contains('Health and Safety Executive Import Licensing Firearms and Ammunition')
     })
     it('✅ 3.P&R:ATT - Attestation Document (horticulture and potatoes)', function () {
-        cy.visit('/commodities/1210209099#import')
+        cy.visit('/xi/commodities/1210209099#import')
         cy.get('#measure-20133446').contains('Conditions').click()
         cy.contains('Attestation Document (horticulture and potatoes) for All countries')
     })
     //exports
     it.skip('🚫 4.P&R:CEX - DCMS Open General Export Licence', function () {
-        cy.visit('/commodities/9702000010#export')
+        cy.visit('/xi/commodities/9702000010#export')
         cy.get('#measure-3349252').contains('Conditions').click()
         cy.contains('DCMS Open General Export Licence')
     })
     //exports
     it.skip('🚫 6.P&R:COE - Home Office Controlled Drugs (export)', function () {
-        cy.visit('/commodities/2934910000#export')
+        cy.visit('/xi/commodities/2934910000#export')
         cy.get('.govuk-tabs__panel')
         cy.contains('Home Office Controlled Drugs (export)').should('not.exist')
     })
     it('✅ 7.P&R:COI HMI Conformity Certificate (fruit and veg) issued in UK', function () {
-        cy.visit('/commodities/0806101090#import')
+        cy.visit('/xi/commodities/0806101090#import')
         cy.get('#measure-20132660').contains('Conditions').click()
         cy.contains('HMI Conformity Certificate (fruit and veg) issued in UK')
     })
     it('✅ 8.P&R:CVD - Common Veterinary Entry Document (CVED)', function () {
-        cy.visit('/commodities/1605531090#import')
+        cy.visit('/xi/commodities/1605531090#import')
         cy.get('#measure-20136665').contains('Conditions').click()
         cy.contains('Veterinary control for All third countries')
     })
     //export
     it.skip('🚫 12.P&R:EQC Certificate of Conformity - export ', function () {
-        cy.visit('/commodities/0709939000#export')
+        cy.visit('/xi/commodities/0709939000#export')
         cy.get('.govuk-tabs__panel')
         cy.contains('Certificate of Conformity').should('not.exist')
     })
     //export
     it.skip('🚫 14.P&R:HOP Home Office pre-cursor chemical authorisation - export ', function () {
-        cy.visit('/commodities/2932940000#export')
+        cy.visit('/xi/commodities/2932940000#export')
         cy.get('.govuk-tabs__panel')
         cy.contains('Home Office Pre-cursor chemicals').should('not.exist')
     })
 
     it('✅ 15.P&R:HSE Health and Safety Executive (imports)', function () {
-        cy.visit('/commodities/3102309000#import')
+        cy.visit('/xi/commodities/3102309000#import')
         cy.get('#measure-20088577').contains('Conditions').click()
         cy.contains('Health and Safety Executive (imports)')
     })
     it('✅ 17.P&R:PHC-Phytosanitary Certificate (import)', function () {
-        cy.visit('/commodities/0809290000#import')
+        cy.visit('/xi/commodities/0809290000#import')
         cy.get('#measure-20087816').contains('Conditions').click()
         cy.contains('Phytosanitary Certificate (import)')
     })
     //export
     it.skip('🚫 18.P&R:PRE Home Office Pre-cursor chemicals - export ', function () {
-        cy.visit('/commodities/2915240000#export')
+        cy.visit('/xi/commodities/2915240000#export')
 
         cy.request()
         cy.reload()
@@ -113,12 +111,12 @@ describe('🇪🇺 💡 Quotas to be suppressed for XI version ,P&R to be availa
         cy.contains('Home Office Pre-cursor chemicals').should('not.exist')
     })
     it('✅ 19.P&R:PRT Home Office Controlled Drugs (import)', function () {
-        cy.visit('/commodities/1211500000#import')
+        cy.visit('/xi/commodities/1211500000#import')
         cy.get('#measure-20087962').contains('Conditions').click()
         cy.contains('Home Office Controlled Drugs (import)')
     })
     it('✅ 20.P&R:QRC Quarantine Release Certificate', function () {
-        cy.visit('/commodities/4403219090#import')
+        cy.visit('/xi/commodities/4403219090#import')
         cy.get('#measure-20088618').contains('Conditions').click()
         cy.contains('Quarantine Release Certificate')
     })

--- a/cypress/integration/XI/FE/quotasSearch-XI.spec.js
+++ b/cypress/integration/XI/FE/quotasSearch-XI.spec.js
@@ -1,15 +1,13 @@
 describe('🇪🇺 💡 ⚙️ quotas Search -XI services)',function() {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('⚙️ 🚫 API - XI quota search page 404', function () {
-        cy.request({method: 'GET', url: '/api/v2/quota_search', failOnStatusCode: false}).as('comments')
+        cy.request({method: 'GET', url: '/xi/api/v2/quota_search', failOnStatusCode: false}).as('comments')
         cy.get('@comments')
             .then((response) => {
                 expect(response.status).to.eq(404)
             })
     })
     it('💡 🚫 Quotas search should not exist on tools page ',function(){
-            cy.visit('/tools')
+            cy.visit('/xi/tools')
             !cy.get('.govuk-list')
                 .contains('Quotas').should('not.exist')
 

--- a/cypress/integration/XI/FE/searchTariff-XI.spec.js
+++ b/cypress/integration/XI/FE/searchTariff-XI.spec.js
@@ -1,9 +1,6 @@
 describe(' 🇪🇺 💡 🔍 | searchTariff-XI |Search the Tariff - XI |',function() {
-
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('XI - Search Commodity by name ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         //changes made on 11/02/2021
         cy.contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
         //changes made on 11/02/2021
@@ -20,7 +17,7 @@ describe(' 🇪🇺 💡 🔍 | searchTariff-XI |Search the Tariff - XI |',funct
     })
 
     it('XI - Search Commodity by code ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
         cy.get('.govuk-label')
             .contains('Search the Northern Ireland Online Tariff')
@@ -33,7 +30,7 @@ describe(' 🇪🇺 💡 🔍 | searchTariff-XI |Search the Tariff - XI |',funct
 
 
     it('XI - Search Commodity by heading code - displays headings page', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
         cy.get('.js-commodity-picker-select').click().type('38089410')
         cy.wait(750)
@@ -41,7 +38,7 @@ describe(' 🇪🇺 💡 🔍 | searchTariff-XI |Search the Tariff - XI |',funct
         cy.contains('Choose the commodity code below that best matches your goods to see more information')
     })
     it('XI - Search unknown commodity ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
         cy.get('.js-commodity-picker-select').click().type('sdfdasdfafsfdfsfsfffsdfsfsfsfsafasfsfsafsafsdfsdfdsaf')
         cy.wait(900)
@@ -53,14 +50,14 @@ describe(' 🇪🇺 💡 🔍 | searchTariff-XI |Search the Tariff - XI |',funct
         cy.contains('All sections')
     })
     it('XI - Import tab - text',function(){
-        cy.visit('commodities/2009909500#import')
+        cy.visit('/xi/commodities/2009909500#import')
         cy.get('.govuk-heading-m')
             .contains('Measures and restrictions for exporting goods from Northern Ireland')
         cy.get('.govuk-label')
             .contains('NI imports from')
     })
     it('XI - Export tab - text',function(){
-        cy.visit('commodities/2009909500#export')
+        cy.visit('/xi/commodities/2009909500#export')
         cy.get('.govuk-heading-m')
             .contains('Measures and restrictions for exporting goods from Northern Ireland')
         cy.get('.govuk-label')

--- a/cypress/integration/XI/FE/sectionsPage-XI.spec.js
+++ b/cypress/integration/XI/FE/sectionsPage-XI.spec.js
@@ -1,14 +1,12 @@
 describe('🇪🇺 💡 🔍 | sectionsPage-XI |Sections page content validation ',function() {
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('Search the tariff text/box visible',function(){
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-label').should('be.visible')
         cy.get('.js-commodity-picker-select.js-show  input#q').should('be.visible')
     })
     it('Top menu section displayed ', function () {
         cy.url().should('include', 'sections', {timeout: 5000})
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header ')
         cy.contains('Search or browse the Tariff')
         cy.contains('A-Z')

--- a/cypress/integration/XI/FE/smokeTest-XI.spec.js
+++ b/cypress/integration/XI/FE/smokeTest-XI.spec.js
@@ -1,17 +1,14 @@
 
 describe('🚀 XI 🇪🇺 💡 | smokeTest-XI.spec | Smoke test to cover basic functionality on XI services |',function() {
-   
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     //Main Page
     it('🚀 XI - Main Page Validation', function () {
         
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.MainPageXI();
     })
     //switching link works
     it('🚀 XI - Main Page - Switching link to UK available & works', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
 
@@ -31,7 +28,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI.spec | Smoke test to cover basic 
     })
     // UK not to be in EU country list
     it('🚀 XI - United Kingdom should NOT be shown in EU country list', function () {
-        cy.visit('/commodities/2403991000#import')
+        cy.visit('/xi/commodities/2403991000#import')
         cy.get('.govuk-tabs__panel')
             .contains('European Economic Area (2012)').click()
         cy.get('.govuk-list')
@@ -41,7 +38,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI.spec | Smoke test to cover basic 
     })
     //Commodity Search functionality - text search
     it('🚀 XI - Search Commodity by name ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         //changed on 11/02/2021
         cy.contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
         //changed on 11/02/2021
@@ -58,7 +55,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI.spec | Smoke test to cover basic 
     })
     //Commodity Search functionality - comm code search
     it('🚀 XI - Search Commodity by code ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
         cy.get('.govuk-label')
             .contains('Search the Northern Ireland Online Tariff')
@@ -71,7 +68,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI.spec | Smoke test to cover basic 
     })
 
     it('🚀 XI - Country Selection -import ', function () {
-        cy.visit('/commodities/0208909800#import')
+        cy.visit('/xi/commodities/0208909800#import')
         // XI Present
         cy.get('input#import_search_country').click().clear().wait(500).type('(XI)').wait(500)
         cy.get("[id='import_search_country__listbox']")
@@ -94,7 +91,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI.spec | Smoke test to cover basic 
 
     })
     it('🚀 XI - Country Selection -export ', function () {
-        cy.visit('/commodities/0208909800#export')
+        cy.visit('/xi/commodities/0208909800#export')
         // XI Present
         cy.get('input#export_search_country').click().clear().wait(500)
             .type('(XI)').wait(500)
@@ -118,7 +115,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI.spec | Smoke test to cover basic 
     })
     //Date picker working and persists on UK XI sites
     it('🚀 XI - Change Date and check if the data shown is same for both XI and UK', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.js-show.sections-context.text > a[role=\'button\']').click()
         cy.get('input#tariff_date_date')
             .clear()
@@ -146,7 +143,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI.spec | Smoke test to cover basic 
             for (let i=0 ;i<sizes.length ;i++){
                 cy.viewport(`${sizes[i]}`)
    
-                cy.visit('/sections')
+                cy.visit('/xi/sections')
                 cy.get('.govuk-header').should('be.visible', 'Northern Ireland Online Tariff')
                 cy.get('.govuk-header__menu-button').click()
                 cy.contains('A-Z')

--- a/cypress/integration/XI/FE/switchingLinks-XI.spec.js
+++ b/cypress/integration/XI/FE/switchingLinks-XI.spec.js
@@ -1,9 +1,7 @@
 describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and related links removed  - (XI version)',function() {
     //--- HOTT-96 ,HOTT- 163 -------------
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('Sections Page - Switching link & text available,forum links removed', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         //check header has Xi information
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
@@ -44,7 +42,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
 
     })
     it('Chapters Page - switching link available,forum links removed', function () {
-        cy.visit('/chapters/01')
+        cy.visit('/xi/chapters/01')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
         cy.get('.govuk-main-wrapper')
@@ -68,7 +66,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
             .should('not.have.text', 'Discuss this chapter in the forums')
     })
     it('Headings Page - switching link available,forum links removed', function () {
-        cy.visit('/headings/0101')
+        cy.visit('/xi/headings/0101')
         //are we on the right page
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
@@ -93,7 +91,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
             .should('not.have.text', 'Discuss this chapter in the forums')
     })
     it('Commodity Page',function(){
-        cy.visit('/commodities/0406103010')
+        cy.visit('/xi/commodities/0406103010')
         //are we on the right page
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
@@ -114,7 +112,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
 
     })
     it('Tools Page',function(){
-        cy.visit('/tools')
+        cy.visit('/xi/tools')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
         //UK switch link
@@ -135,7 +133,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
 
     })
     it.skip('Quota Search Page',function(){
-        cy.visit('/quota_search')
+        cy.visit('/xi/quota_search')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
         //UK switch link
@@ -155,7 +153,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
             .contains('UK Global Online Tariff')
     })
     it('Certificate Search Page',function(){
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
         //UK switch link
@@ -175,7 +173,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
             .contains('UK Global Online Tariff')
     })
     it('Additional Code Search Page',function(){
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
         //UK switch link
@@ -195,7 +193,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
             .contains('UK Global Online Tariff')
     })
     it('Chemical Search Page',function(){
-        cy.visit('/chemical_search')
+        cy.visit('/xi/chemical_search')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
         //UK switch link
@@ -215,7 +213,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
             .contains('UK Global Online Tariff')
     })
     it('A-Z Page',function(){
-        cy.visit('/a-z-index/a')
+        cy.visit('/xi/a-z-index/a')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
         //UK switch link

--- a/cypress/integration/XI/FE/titleTags-XI.spec.js
+++ b/cypress/integration/XI/FE/titleTags-XI.spec.js
@@ -1,33 +1,30 @@
 describe('🇪🇺 💡 | titleTags-XI | Validating page titles tags - meta data -XI', function () {
-
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('🧷 Landing Page - Northern Ireland Online Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.log(cy.title())
        cy.title().should('eq','Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates - GOV.UK')
 
     })
     it('🧷 Section Page - Live animals; animal products - The Northern Ireland (EU) Tariff - GOV.UK', function () {
-        cy.visit('/sections/1')
+        cy.visit('/xi/sections/1')
         cy.log(cy.title())
         cy.title().should('eq','Live animals; animal products - Northern Ireland Online Tariff - GOV.UK')
 
     })
     it('🧷 Chapter Page - Live animals - Northern Ireland Online Tariff - GOV.UK', function () {
-        cy.visit('/chapters/01')
+        cy.visit('/xi/chapters/01')
         cy.log(cy.title())
         cy.title().should('eq','Live animals - Northern Ireland Online Tariff - GOV.UK')
 
     })
     it('🧷 Headings Page - Live horses, asses, mules and hinnies - Northern Ireland Online Tariff - GOV.UK', function () {
-        cy.visit('/headings/0101')
+        cy.visit('/xi/headings/0101')
         cy.log(cy.title())
         cy.title().should('eq','Live horses, asses, mules and hinnies - Northern Ireland Online Tariff - GOV.UK')
 
     })
     it('🧷 Commodity Page - Commodity code 0101210000: Pure-bred breeding animals - Northern Ireland Online Tariff - GOV.UK ', function () {
-        cy.visit('/commodities/0101210000')
+        cy.visit('/xi/commodities/0101210000')
         cy.log(cy.title())
         cy.title().should('eq','Commodity code 0101210000: Pure-bred breeding animals - Northern Ireland Online Tariff - GOV.UK')
 

--- a/cypress/integration/XI/FE/toolsSection-XI.spec.js
+++ b/cypress/integration/XI/FE/toolsSection-XI.spec.js
@@ -1,9 +1,7 @@
 describe('🇪🇺 💡 | toolsSection-XI |Tools Section - breadcrumbs   - (XI version)', function () {
     // HOTT-94
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     it('Tools Section in header ', function () {
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header').should('be.visible', 'Northern Ireland Online Tariff')
             .contains('Tools').click()
         cy.contains('Tariff tools')
@@ -13,7 +11,7 @@ describe('🇪🇺 💡 | toolsSection-XI |Tools Section - breadcrumbs   - (XI v
 
     })
     it('breadcrumbs - No Quotas ', function () {
-        cy.visit('/tools')
+        cy.visit('/xi/tools')
         // XI not to have quotas 
         cy.get('.govuk-breadcrumbs__list')
             .contains('Tools').click()
@@ -24,7 +22,7 @@ describe('🇪🇺 💡 | toolsSection-XI |Tools Section - breadcrumbs   - (XI v
     })
 
     it('breadcrumbs - Certificates ,licences and documents', function () {
-        cy.visit('/certificate_search')
+        cy.visit('/xi/certificate_search')
         cy.contains('Search by Certificate')
         cy.get('.govuk-breadcrumbs')
             .contains('Certificate')
@@ -37,7 +35,7 @@ describe('🇪🇺 💡 | toolsSection-XI |Tools Section - breadcrumbs   - (XI v
 
     })
     it('breadcrumbs - Additional codes', function () {
-        cy.visit('/additional_code_search')
+        cy.visit('/xi/additional_code_search')
         cy.contains('Search by Additional Code')
         cy.get('.govuk-breadcrumbs')
             .contains('Additional codes')
@@ -50,7 +48,7 @@ describe('🇪🇺 💡 | toolsSection-XI |Tools Section - breadcrumbs   - (XI v
 
     })
     it('breadcrumbs - Chemicals', function () {
-        cy.visit('/chemical_search')
+        cy.visit('/xi/chemical_search')
         cy.contains('Search by Chemical')
         cy.get('.govuk-breadcrumbs')
             .contains('Chemicals')

--- a/cypress/integration/XI/XIMobile/smokeTest-XI-M.spec.js
+++ b/cypress/integration/XI/XIMobile/smokeTest-XI-M.spec.js
@@ -1,8 +1,6 @@
 
 describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic functionality on XI services ',function() {
    
-    Cypress.config('baseUrl', Cypress.config('services')['xi'])
-
     //Main Page
     it(`🚀 XI - Mobile - nav-bar validation`,function(){
         
@@ -10,7 +8,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
             for (let i=0 ;i<sizes.length ;i++){
                 cy.viewport(`${sizes[i]}`)
    
-                cy.visit('/sections')
+                cy.visit('/xi/sections')
                 cy.get('.govuk-header').should('be.visible', 'Northern Ireland Online Tariff')
                 cy.get('.govuk-header__menu-button').click()
                 cy.contains('A-Z')
@@ -24,7 +22,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
     //Legal base tests
     it('🚀 XI - Legal base column suppressed', function () {
         cy.viewport('iphone-x')
-        cy.visit('/commodities/0101210000#import')
+        cy.visit('/xi/commodities/0101210000#import')
         cy.contains('Northern Ireland Online Tariff')
         cy.get('.govuk-tabs__panel')
         cy.contains('Legal base').should('not.exist')
@@ -32,7 +30,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
     //switching link works
     it('🚀 XI - Main Page - Switching link to UK available & works', function () {
         cy.viewport('iphone-x')
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.govuk-header ')
             .contains('Northern Ireland Online Tariff')
 
@@ -53,7 +51,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
     // UK not to be in EU country list
     it('🚀 XI - United Kingdom should NOT be shown in EU country list', function () {
         cy.viewport('iphone-x')
-        cy.visit('/commodities/2403991000#import')
+        cy.visit('/xi/commodities/2403991000#import')
         cy.get('.govuk-tabs__panel')
             .contains('European Economic Area (2012)').click()
         cy.get('.govuk-list')
@@ -64,7 +62,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
     //Commodity Search functionality - text search
     it('🚀 XI - Search Commodity by name ', function () {
         cy.viewport('iphone-x')
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         //changed on 11/02/2021
         cy.contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
         //changed on 11/02/2021
@@ -82,7 +80,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
     //Commodity Search functionality - comm code search
     it('🚀 XI - Search Commodity by code ', function () {
         cy.viewport('iphone-x')
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.contains('Northern Ireland Online Tariff: look up commodity codes, duty and VAT rates')
         cy.get('.govuk-label')
             .contains('Search the Northern Ireland Online Tariff')
@@ -96,7 +94,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
 
     it('🚀 XI - Country Selection -import ', function () {
         cy.viewport('iphone-x')
-        cy.visit('/commodities/0208909800#import')
+        cy.visit('/xi/commodities/0208909800#import')
         // XI Present
         cy.get('input#import_search_country').click().clear().wait(500).type('(XI)').wait(500)
         cy.get("[id='import_search_country__listbox']")
@@ -120,7 +118,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
     })
     it('🚀 XI - Country Selection -export ', function () {
         cy.viewport('iphone-x')
-        cy.visit('/commodities/0208909800#export')
+        cy.visit('/xi/commodities/0208909800#export')
         // XI Present
         cy.get('input#export_search_country').click().clear().wait(500)
             .type('(XI)').wait(500)
@@ -145,7 +143,7 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
     //Date picker working and persists on UK XI sites
     it('🚀 XI - Change Date and check if the data shown is same for both XI and UK', function () {
         cy.viewport('iphone-x')
-        cy.visit('/sections')
+        cy.visit('/xi/sections')
         cy.get('.js-show.sections-context.text > a[role=\'button\']').click()
         cy.get('input#tariff_date_date')
             .clear()

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,10 +21,12 @@ import 'cypress-fill-command'
 //import ‘cypress-audit/commands’
 require('cypress-grep')()
 
+Cypress.config('baseUrl', Cypress.env('baseUrl'))
+
 Cypress.on('uncaught:exception', (err, runnable) => {
-    // returning false here prevents Cypress from
-    // failing the test
-    return false
-  })
+  // returning false here prevents Cypress from
+  // failing the test
+  return false
+})
 
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "uktests": "npx cypress run --spec \"/*/**/UK/**/*spec.js\"",
     "dctests": "cypress run --spec \"/*/**/DutyCalculator/**/*spec.js\" --browser chrome --headless --reporter mocha-allure-reporter",
     "report:allure": "allure generate allure-results --clean -o allure-report && allure open allure-report",
-    "test:allure": "npm run dctests && npm run report:allure"
+    "test:allure": "npm run dctests && npm run report:allure",
+    "open:dev": "npx cypress open --env baseUrl=https://dev.trade-tariff.service.gov.uk",
+    "open:staging": "npx cypress open --env baseUrl=https://staging.trade-tariff.service.gov.uk",
+    "open:prod": "npx cypress open --env baseUrl=https://www.trade-tariff.service.gov.uk"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [ ] Use baseURL everywhere and rely on path to pick between services and duty calculator

### Why?

I am doing this because:

- This means we can easily write scripts which execute under a different environment (space in cloud foundry speak)
