### PR TITLE
Handle running tests outside of an npm script

### DIFF
--- a/cypress/integration/HOTT-Shared/smokeTestUKXI.spec.js
+++ b/cypress/integration/HOTT-Shared/smokeTestUKXI.spec.js
@@ -1,8 +1,5 @@
 
 describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | smokeTest- UK & XI | Smoke tests to cover basic functionality on UK & XI services |', function () {
-
-    Cypress.config('baseUrl')
-
     //Main Page
     it('🚀 UK 🇬🇧 - Main Page Validation', function () {
         cy.visit('/sections')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,7 +21,9 @@ import 'cypress-fill-command'
 //import ‘cypress-audit/commands’
 require('cypress-grep')()
 
-Cypress.config('baseUrl', Cypress.env('baseUrl'))
+let baseUrl = Cypress.env('baseUrl') || 'https://staging.trade-tariff.service.gov.uk'
+
+Cypress.config('baseUrl', baseUrl)
 
 Cypress.on('uncaught:exception', (err, runnable) => {
   // returning false here prevents Cypress from


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds handling for running tests without a package.json script

### Why?

I am doing this because:

- This enables me to run tests in my editor or on the CLI without the baseUrl as an argument
