### PR TITLE
Enable passing CYPRESS_BASE_URL in all contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,10 @@ version: 2.1
 orbs:
   cypress: cypress-io/cypress@1.27.0
   slack: circleci/slack@4.1
+executor:
+  cypress/browsers-chrome77:
+    environment:
+      CYPRESS_BASE_URL: "https://staging.trade-tariff.service.gov.uk"
 
 workflows:
   debug:
@@ -9,7 +13,6 @@ workflows:
       - cypress/run:
           context: trade-tariff
           name: "🚀 UK XI & DC Smoke tests"
-          executor: cypress/browsers-chrome77
           browser: chrome
           store_artifacts: true
           spec: "*/**/smokeTestCI.spec.js"
@@ -56,11 +59,10 @@ workflows:
     jobs:
       - cypress/run:
           context: trade-tariff
-          name: "🚀 UK & XI Smoke tests"
-          executor: cypress/browsers-chrome77
+          name: "🚀 UK XI & DC Smoke tests scheduled"
           browser: chrome
           store_artifacts: true
-          spec: "*/**/smokeTestUKXI.spec.js"
+          spec: "*/**/smokeTestCI.spec.js"
           post-steps:
             - store_test_results:
                 path: cypress/results

--- a/.github/workflows/dctests.yml
+++ b/.github/workflows/dctests.yml
@@ -2,6 +2,8 @@ name: " 💰📊 | Duty Calculator Regression Pack |"
 on: [workflow_dispatch]
 jobs:
   cypress-run:
+    env:
+      CYPRESS_BASE_URL: 'https://staging.trade-tariff.service.gov.uk'
     name: "💰 Duty Calculator Regression Tests"
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/dctestsnoreport.yml
+++ b/.github/workflows/dctestsnoreport.yml
@@ -2,6 +2,8 @@ name: " 💰 | Duty Calculator Regression Pack Without Reporting |"
 on: [workflow_dispatch]
 jobs:
   cypress-run:
+    env:
+      CYPRESS_BASE_URL: 'https://staging.trade-tariff.service.gov.uk'
     name: "💰 Duty Calculator Regression Tests"
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/dutySmoke.yml
+++ b/.github/workflows/dutySmoke.yml
@@ -1,8 +1,9 @@
 name: "💨 Duty Cal smoke test"
 on: [workflow_dispatch]
-#on: [push]
 jobs:
   cypress-run:
+    env:
+      CYPRESS_BASE_URL: 'https://staging.trade-tariff.service.gov.uk'
     name: DC Smoke on Chrome
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 jobs:
   cypress-run:
+    env:
+      CYPRESS_BASE_URL: 'https://www.trade-tariff.service.gov.uk'
     name: "🚦 Regression Tests - UK and XI"
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/smoketestsAll.yml
+++ b/.github/workflows/smoketestsAll.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
 jobs:
   cypress-run:
+    env:
+      CYPRESS_BASE_URL: 'https://staging.trade-tariff.service.gov.uk'
     name: "smoke tests - UK and XI"
     runs-on: ubuntu-18.04
     strategy:

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl": "https://staging.trade-tariff.service.gov.uk",
   "services": {
     "docker": "http://localhost:3000/duty-calculator"
   },

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,10 +21,6 @@ import 'cypress-fill-command'
 //import ‘cypress-audit/commands’
 require('cypress-grep')()
 
-let baseUrl = Cypress.env('baseUrl') || 'https://staging.trade-tariff.service.gov.uk'
-
-Cypress.config('baseUrl', baseUrl)
-
 Cypress.on('uncaught:exception', (err, runnable) => {
   // returning false here prevents Cypress from
   // failing the test

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "dctests": "cypress run --spec \"/*/**/DutyCalculator/**/*spec.js\" --browser chrome --headless --reporter mocha-allure-reporter",
     "report:allure": "allure generate allure-results --clean -o allure-report && allure open allure-report",
     "test:allure": "npm run dctests && npm run report:allure",
-    "open:dev": "npx cypress open --env baseUrl=https://dev.trade-tariff.service.gov.uk",
-    "open:staging": "npx cypress open --env baseUrl=https://staging.trade-tariff.service.gov.uk",
-    "open:prod": "npx cypress open --env baseUrl=https://www.trade-tariff.service.gov.uk"
+    "open:dev": "CYPRESS_BASE_URL=https://dev.trade-tariff.service.gov.uk npx cypress open",
+    "open:staging": "CYPRESS_BASE_URL=https://staging.trade-tariff.service.gov.uk npx cypress open",
+    "open:prod": "CYPRESS_BASE_URL=https://www.trade-tariff.service.gov.uk npx cypress open"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# What?

Currently there are three contexts in which we use cypress:

1. When exploring specific tests in the test browser (npm run
   open:staging)
2. When running workflows (using CYPRESS_BASE_URL)
3. When running in an editor (using the baseUrl variable in the
   cypress.json file)
4. When running in circle ci on a schedule

This PR supports these three contexts and fixes the cypress failures
in github workflows.
