### PR TITLE
fix console output errors

### DIFF
--- a/cypress/integration/DutyCalculator/dcShared/dcDutyCalculatorLink.spec.js
+++ b/cypress/integration/DutyCalculator/dcShared/dcDutyCalculatorLink.spec.js
@@ -2,18 +2,21 @@ describe('💡 | dcDutyCalculatorLink | Duty Cal link on Comcodes + supressed on
     let country = ["", "xi"]
     let pagetitles = ["UK Integrated Online Tariff", "Northern Ireland Online Tariff"]
     for (let j = 0; j < country.length; j++) {
-        console.log(j)
+     //   console.log(j)
 
-    it(`${country[j]} - Duty calculator link to be suppressed on commodities which are also headings `, function () {
+    it.only(`${country[j]} - Duty calculator link to be suppressed on commodities which are also headings `, function () {
         let comms = ["0409000000","0510000000","8804000000","2509000000","2802000000","3101000000","3914000000","4004000000","4812000000","5001000000","4112000000","4705000000"]
         for (let i=0;i<comms.length;i++)
         {
         cy.visit(`${country[j]}/sections`)
         cy.contains(`${pagetitles[j]}`)
+/*
         cy.get('.js-commodity-picker-select').click().type(`${comms[i]}`)
         cy.wait(950)
         cy.get('input[name=\'new_search\']').click()
         cy.wait(650)
+*/
+        cy.searchForCommodity(`${comms[i]}`)
         cy.contains(`Commodity information for ${comms[i]}`)
         cy.contains('Duty calculation').should('not.exist')
         }

--- a/cypress/integration/UK/API/btiUrlAPI-UK.spec.js
+++ b/cypress/integration/UK/API/btiUrlAPI-UK.spec.js
@@ -7,7 +7,7 @@ context('🇬🇧 ⚙️ UK - Update bti URL on V1 and V2 ', () => {
             url: '/api/v2/commodities/0202201011'
         }).then((response) => {
             expect(response.status).to.eq(200);
-     //       console.log(JSON.stringify(response.body))
+     //      console.log(JSON.stringify(response.body))
             expect(response.body).not.to.be.null
             expect(response.body.data.attributes).to.have.property('bti_url')
                 .contains('https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code')
@@ -20,7 +20,7 @@ context('🇬🇧 ⚙️ UK - Update bti URL on V1 and V2 ', () => {
             url: '/api/v1/commodities/0202201011'
         }).then((response) => {
             expect(response.status).to.eq(200);
-            console.log(JSON.stringify(response.body))
+       //     console.log(JSON.stringify(response.body))
             expect(response.body).not.to.be.null
             expect(response.body).to.have.property('bti_url')
                 .contains('https://www.gov.uk/guidance/check-what-youll-need-to-get-a-legally-binding-decision-on-a-commodity-code')

--- a/cypress/integration/UK/API/commcodesAPIvalidation-UK.spec.js
+++ b/cypress/integration/UK/API/commcodesAPIvalidation-UK.spec.js
@@ -10,8 +10,8 @@ context('🇬🇧 ⚙️ | commcodesAPIvalidation-UK |Validate API response for 
                     url: `/api/v2/commodities/${commodity_ids[i]}`
                 }).then((response) => {
                     expect(response.status).to.eq(200);
-                    console.log(JSON.stringify(fixture))
-                    console.log(JSON.stringify(response.body))
+                //    console.log(JSON.stringify(fixture))
+                 //   console.log(JSON.stringify(response.body))
                  //   expect(response.body).to.deep.equal(fixture)
 
 
@@ -25,7 +25,7 @@ context('🇬🇧 ⚙️ | commcodesAPIvalidation-UK |Validate API response for 
         let fixture_timestamp = Cypress.config('fixtures_timestamp');
         let commodity_ids = Cypress.config('commcodes');
         for (let i = 0; i < commodity_ids.length; i++) {
-            cy.log(`🇬🇧 ⚙️  for comm code ${commodity_ids[i]}`)
+        //    cy.log(`🇬🇧 ⚙️  for comm code ${commodity_ids[i]}`)
             cy.request(`./api/v2/commodities/${commodity_ids[i]}`).then($response => {
                 expect($response.status).to.eq(200)
 
@@ -54,8 +54,8 @@ context('🇬🇧 ⚙️ | commcodesAPIvalidation-UK |Validate API response for 
                     url: `/api/v1/commodities/${commodity_ids[i]}`
                 }).then((response) => {
                     expect(response.status).to.eq(200);
-                    console.log(JSON.stringify(fixture))
-                    console.log(JSON.stringify(response.body))
+               //     console.log(JSON.stringify(fixture))
+               //     console.log(JSON.stringify(response.body))
                  //   expect(response.body).to.deep.equal(fixture)
                 })
             })
@@ -66,7 +66,7 @@ context('🇬🇧 ⚙️ | commcodesAPIvalidation-UK |Validate API response for 
         let fixture_timestamp = Cypress.config('fixtures_timestamp');
         let commodity_ids = Cypress.config('commcodes');
         for (let i = 0; i < commodity_ids.length; i++) {
-            cy.log(`🇬🇧 ⚙️ for comm code ${commodity_ids[i]}`)
+         //   cy.log(`🇬🇧 ⚙️ for comm code ${commodity_ids[i]}`)
             cy.request(`./api/v1/commodities/${commodity_ids[i]}`).then($response => {
                 expect($response.status).to.eq(200)
 


### PR DESCRIPTION
remove `console.log` in API tests 

-  they are not required 
- publishes complete api response in console 