### PR TITLE
Retain reports

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -13,8 +13,11 @@ jobs:
       fail-fast: false
     steps:
       - run: date
+
       - uses: actions/checkout@v2
+
       - run: mkdir -p cypress/reports/mochareports
+
       - uses: cypress-io/github-action@v2
         name: "All tests"
         continue-on-error: true
@@ -23,28 +26,45 @@ jobs:
           browser: chrome
           headless: true       
           spec: "*/**/**/*spec.js"
+
       - run: npm run posttests
+
       - run: ls -l
+
       - uses: actions/upload-artifact@v2
         with:
           name: report
           path: ./cypress/reports/mochareports/
-      - run: |
+
+      - name: Checkout reports repo
+        uses: actions/checkout@v2
+        with:
+          ref: reports
+          path: reports_repo
+
+      - name: Copy report into reports repo
+        run: |
+          cd reports_repo
           DATE=$(date +%d-%m-%Y)
           mkdir -p docs/$DATE
-          cp -r ./cypress/reports/mochareports/*  docs/$DATE/
-          cp ./cypress/reports/mochareports/report.html docs/$DATE/index.html
+          cp -r ../cypress/reports/mochareports/*  docs/$DATE/
+          cp ../cypress/reports/mochareports/report.html docs/$DATE/index.html
           git add docs .
-      - run: |
-           git config --local user.email "tradetarrif+github-actions[bot]@users.noreply.github.com"
-           git config --local user.name "github-actions[bot]"
-           git commit -m "Add changes" -a
+
+      - name: Commit todays report to reports branch
+        run: |
+          cd reports_repo
+          git config --local user.email "tradetarrif+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Production report for $(date +%d-%m-%Y)" -a
+
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: reports
-          force: true
+          directory: reports_repo
+
       - uses: cypress-io/github-action@v2
         name: " Cypress Dashboard "
         continue-on-error: true

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -1,10 +1,10 @@
 name: " 🛎️ | Regression Pack | Staging |"
+
 on:
   schedule:
     - cron: "00 04 * * *"
   workflow_dispatch:
- # push:
- #   branches: [sprint20]
+
 jobs:
   cypress-run:
     env:
@@ -15,8 +15,11 @@ jobs:
       fail-fast: false
     steps:
       - run: date
+
       - uses: actions/checkout@v2
+
       - run: mkdir -p cypress/reports/mochareports
+
       - uses: cypress-io/github-action@v2
         name: cypress
         id: cypress
@@ -26,35 +29,59 @@ jobs:
           browser: chrome
           headless: true       
           spec: "*/**/**/*.spec.js"
+
       - run: npm run posttests
+
       - run: ls -l
+
       - uses: actions/upload-artifact@v2
         with:
           name: report
           path: ./cypress/reports/mochareports/
-      - run: |
+
+      - name: Checkout reports repo
+        uses: actions/checkout@v2
+        with:
+          ref: reports
+          path: reports_repo
+
+      - name: Copy report into reports repo
+        run: |
+          cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          mkdir -p docs/$DATE
-          cp -r ./cypress/reports/mochareports/*  docs/$DATE/
-          cp ./cypress/reports/mochareports/report.html docs/$DATE/index.html
+          mkdir -p docs/staging/$DATE
+          cp -r ../cypress/reports/mochareports/*  docs/staging/$DATE/
+          cp ../cypress/reports/mochareports/report.html docs/staging/$DATE/index.html
+
           git add docs .
-      - run: |
-           git config --local user.email "tradetarrif+github-actions[bot]@users.noreply.github.com"
-           git config --local user.name "github-actions[bot]"
-           git commit -m "Add changes" -a
-      
+
+      - name: Commit todays report to reports branch
+        run: |
+          cd reports_repo
+          git config --local user.email "tradetarrif+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Staging report for $(date +%d-%m-%Y)" -a
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: reports
+          directory: reports_repo
+
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2 
         if: ${{ steps.cypress.outcome == 'failure' }}
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
-      # - name: Push changes
-      #   uses: ad-m/github-push-action@master
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     branch: reports
-      #     force: true
+
       - uses: cypress-io/github-action@v2
         name: " Cypress Dashboard "
         continue-on-error: true


### PR DESCRIPTION
### Jira link

[HOTT-933](https://transformuk.atlassian.net/browse/HOTT-933)

### What?

I have added/removed/altered:

- [x] Added checkout of reports branch in staging regression action
- [x] Commit reports to reports branch instead of master in staging regression action
- [x] Push to reports branch on origin from reports checkout instead of master checkout in staging regression action
- [x] Same 3 changes for the production regression suite

### Why?

I am doing this because:

- We are currently overwriting the reports every night and wish to be retaining each days reports from both staging and production
