### PR TITLE
HOTT-1076 loosened the string check for the commodity page

### DIFF
--- a/cypress/integration/HOTT-Shared/devSmokeTestCI.spec.js
+++ b/cypress/integration/HOTT-Shared/devSmokeTestCI.spec.js
@@ -70,7 +70,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
     cy.get('.govuk-label')
         .contains('Search the UK Integrated Online Tariff');
     cy.searchForCommodity('3808941000');
-    cy.contains('Commodity information for 3808941000');
+    cy.contains(/Commodity .*3808941000/i);
   });
 
   // Date picker working and persists on UK XI sites
@@ -166,6 +166,6 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
     cy.get('.govuk-label')
         .contains('Search the Northern Ireland Online Tariff');
     cy.searchForCommodity('3808941000');
-    cy.contains('Commodity information for 3808941000');
+    cy.contains(/Commodity .*3808941000/i);
   });
 });


### PR DESCRIPTION
We want to know we're on the right page, but the specific wording is not a concern for the smoketest

### Jira link

[HOTT-1076](https://transformuk.atlassian.net/browse/HOTT-1076)

### What?

I have added/removed/altered:

- [x] Loosened the string check for the commodity page

### Why?

I am doing this because:

- Whilst we want to know we're on the right page, the specific wording is not a concern for the smoketest
- This change ensures smoke tests pass both before and after the merge of https://github.com/trade-tariff/trade-tariff-frontend/pull/399