### PR TITLE
HOTT-1171 Fix smoketests when multiple search forms

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -108,14 +108,14 @@ Cypress.Commands.add('waitForCommoditySearchResults', () => {
 });
 
 Cypress.Commands.add('searchForCommodity', (searchString) => {
-  cy.get('.js-commodity-picker-select').click().type(searchString);
+  cy.get('.js-commodity-picker-select:last').click().type(searchString);
   cy.waitForCommoditySearchResults();
   //  cy.get('input[name=\'new_search\']').click();
   cy.get('input[name=\'commit\']').click();
   //  cy.get('input[name=\'new_search\']').click();
 });
 Cypress.Commands.add('searchForCommodity2', (searchString) => {
-  cy.get('.js-commodity-picker-select').click().type(searchString);
+  cy.get('.js-commodity-picker-select:last').click().type(searchString);
   cy.waitForCommoditySearchResults();
   return cy.get('input[name=\'new_search\']').click();
   // cy.get('input[name=\'commit\']').click();


### PR DESCRIPTION
### Jira link

[HOTT-1171](https://transformuk.atlassian.net/browse/HOTT-1171)

### What?

I have added/removed/altered:

- [x] Fixed the smoke tests which were broken by the second search field in the page

### Why?

I am doing this because:

- my changes broke the smoke tests
