### PR TITLE
Regression fixes - Duty Cal date change to 01-01-2022

### DIFF
--- a/cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB201-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB201-e2e.spec.js
@@ -38,7 +38,7 @@ describe('|RoW-GB201-e2e.spec |🍅 - 🇻🇳 Vietnam to 🇬🇧 GB  | 201-e2e
 
       //   cy.get('.govuk-summary-list__value')
       cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('0702 00 00 07');
-      cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('31 December 2021');
+      cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('01 January 2022');
       cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('England, Scotland or Wales (GB)');
       cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('Vietnam');
       cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('£1,000.00');
@@ -49,7 +49,7 @@ describe('|RoW-GB201-e2e.spec |🍅 - 🇻🇳 Vietnam to 🇬🇧 GB  | 201-e2e
       // Final Page - duty page
       cy.contains('Import duty calculation');
       cy.contains('You are importing commodity');
-      cy.contains('from Vietnam on 31 December 2021.');
+      cy.contains('from Vietnam on 01 January 2022.');
 
       cy.contains('Details of your trade').click();
       cy.get('.govuk-details__text');
@@ -60,7 +60,7 @@ describe('|RoW-GB201-e2e.spec |🍅 - 🇻🇳 Vietnam to 🇬🇧 GB  | 201-e2e
       // values
       cy.contains('0702 00 00 07');
       cy.contains('Cherry tomatoes');
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       cy.contains('£1,000.00');
 
       // information
@@ -81,7 +81,7 @@ describe('|RoW-GB201-e2e.spec |🍅 - 🇻🇳 Vietnam to 🇬🇧 GB  | 201-e2e
       cy.get('tr:nth-of-type(3) > td:nth-of-type(3)').contains('£0.00');
       // Final Page
       cy.contains('Import duty calculation');
-      cy.contains('You are importing commodity 0702 00 00 07 from Vietnam on 31 December 2021.');
+      cy.contains('You are importing commodity 0702 00 00 07 from Vietnam on 01 January 2022.');
       cy.contains('Option 1: Third-country duty');
       cy.contains('Option 2: Tariff preference - Vietnam');
     });

--- a/cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB202-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB202-e2e.spec.js
@@ -51,7 +51,7 @@ describe('|RoW-GB202-e2e.spec |🇹🇷 Turkey to  🇬🇧 GB | 202-e2e.spec | 
       //   cy.get('.govuk-summary-list__value')
       cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('0304 82 90 10');
       cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('B964');
-      cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('31 December 2021');
+      cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('01 January 2022');
       cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('England, Scotland or Wales (GB)');
       cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('Turkey');
       cy.get('div:nth-of-type(6) > .govuk-summary-list__value').contains('£10,002.24');
@@ -62,7 +62,7 @@ describe('|RoW-GB202-e2e.spec |🇹🇷 Turkey to  🇬🇧 GB | 202-e2e.spec | 
       // Final Page - duty page
       cy.contains('Import duty calculation');
       cy.contains('You are importing commodity');
-      cy.contains('from Turkey on 31 December 2021.');
+      cy.contains('from Turkey on 01 January 2022.');
 
       //     cy.contains('0304 82 90 10').click()
       //     cy.checkCommPage('0304829010')
@@ -78,7 +78,7 @@ describe('|RoW-GB202-e2e.spec |🇹🇷 Turkey to  🇬🇧 GB | 202-e2e.spec | 
       // values
       cy.contains('0304 82 90 10');
       cy.contains('0304 82 90 10 (B964) Of the species Oncorhynchus mykiss');
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       cy.contains('£10,002.24');
 
       // information

--- a/cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB203-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB203-e2e.spec.js
@@ -35,7 +35,7 @@ describe('|RoW-GB203-e2e.spec |🍅 China to 🇬🇧 GB  | 201-e2e.spec | ', fu
       cy.contains('Customs value');
 
       cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('0702 00 00 07');
-      cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('31 December 2021');
+      cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('01 January 2022');
       cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('England, Scotland or Wales (GB)');
       cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('Vietnam');
       cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('£10,002.24');
@@ -46,7 +46,7 @@ describe('|RoW-GB203-e2e.spec |🍅 China to 🇬🇧 GB  | 201-e2e.spec | ', fu
       // Final Page - duty page
       cy.contains('Import duty calculation');
       cy.contains('You are importing commodity');
-      cy.contains('from Vietnam on 31 December 2021.');
+      cy.contains('from Vietnam on 01 January 2022.');
 
 
       cy.contains('Details of your trade').click();
@@ -58,7 +58,7 @@ describe('|RoW-GB203-e2e.spec |🍅 China to 🇬🇧 GB  | 201-e2e.spec | ', fu
       // values
       cy.contains('0702 00 00 07');
       cy.contains('Cherry tomatoes');
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       cy.contains('£10,002.24');
 
       // information

--- a/cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI303a-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI303a-e2e.spec.js
@@ -32,8 +32,8 @@ describe('| RoW-NI303a-e2e.spec |🚫 Trade Remedies - 🚫 0% MFN EU tariff - �
     cy.dutyPage();
     cy.contains('Option 1: Third-country duty');
     cy.contains('Third-country duty (EU)');
-    cy.contains('Option 2: Tariff preference - Morocco');
-    cy.contains('Tariff preference (EU)');
+    // cy.contains('Option 2: Tariff preference - Morocco');
+    // cy.contains('Tariff preference (EU)');
   });
   it('RoW 🇲🇦 (Costa Rica) to Northern Ireland - Meursing Code', function() {
     cy.visit('/duty-calculator/xi/1901100000/import-date');

--- a/cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI307-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI307-e2e.spec.js
@@ -41,7 +41,7 @@ describe('| RoW-NI307-e2e.spec | RoW (Argentina) to NI | Additional Codes + Docu
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('You are importing commodity 1516 20 98 21 (C999, C496) from Argentina on 31 December 2021.');
+    cy.contains('You are importing commodity 1516 20 98 21 (C999, C496) from Argentina on 01 January 2022.');
     cy.contains('Option 1: Third-country duty');
     cy.contains('10.90% * £1,000.00');
     cy.contains('172.20 EUR / 1000 kg/biodiesel * 1000.00');
@@ -72,7 +72,7 @@ describe('| RoW-NI307-e2e.spec | RoW (Argentina) to NI | Additional Codes + Docu
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('You are importing commodity 1516 20 98 21 (C999, C496) from Argentina on 31 December 2021.');
+    cy.contains('You are importing commodity 1516 20 98 21 (C999, C496) from Argentina on 01 January 2022.');
     cy.contains('Option 1: Third-country duty');
     cy.contains('10.90% * £1,000.00');
     cy.contains('Import duty (C999)');

--- a/cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI308-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI308-e2e.spec.js
@@ -34,7 +34,7 @@ describe('| RoW-NI308-e2e.spec | RoW (Norway) to NI | Document Code , Retail Pri
     cy.contains('611');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('You are importing commodity 2402 20 90 00 from Norway on 31 December 2021.');
+    cy.contains('You are importing commodity 2402 20 90 00 from Norway on 01 January 2022.');
     // doc code y021 =  Apply the mentioned duty 27.95%
     cy.contains('Option 1: Third-country duty');
     cy.contains('611 - Cigarettes');
@@ -61,7 +61,7 @@ describe('| RoW-NI308-e2e.spec | RoW (Norway) to NI | Document Code , Retail Pri
     cy.contains('611');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('You are importing commodity 2402 20 90 00 from Norway on 31 December 2021.');
+    cy.contains('You are importing commodity 2402 20 90 00 from Norway on 01 January 2022.');
     // doc code No code  =  Measure not applicable
     cy.contains('Option 1: Third-country duty');
     cy.contains('611 - Cigarettes');

--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI404-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI404-e2e.spec.js
@@ -58,7 +58,7 @@ describe('| GB-NI404-e2e.spec | GB to NI route 🚐 04  - 🚫 Trade Remedies - 
       // check values entered
       cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('1701 14 10 00');
       cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('N990');
-      cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('31 December 2021');
+      cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('01 January 2022');
       cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('Northern Ireland');
       cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
       cy.get('div:nth-of-type(6) > .govuk-summary-list__value').contains('Yes');

--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI406-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI406-e2e.spec.js
@@ -58,7 +58,7 @@ describe('| GB-NI406-e2e.spec | EU Duties apply | GB to NI route 06 - 🚫 Trade
       cy.contains('Import quantity');
       //   cy.get('.govuk-summary-list__value')
       cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('1701 14 10 00');
-      cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('31 December 2021');
+      cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('01 January 2022');
       cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('Northern Ireland');
       cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
       cy.get('div:nth-of-type(6) > .govuk-summary-list__value').contains('Yes');

--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI408a-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI408a-e2e.spec.js
@@ -43,7 +43,7 @@ describe('| GB-NI408a-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
 
     //   cy.get('.govuk-summary-list__value')
     cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('7202 11 80 00');
-    cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('31 December 2021');
+    cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('01 January 2022');
     cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('Northern Ireland');
     cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
     cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('No');
@@ -57,7 +57,7 @@ describe('| GB-NI408a-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
     cy.contains('Import duty calculation');
     cy.contains('You are importing commodity');
     cy.contains('from United Kingdom (excluding Northern Ireland) on');
-    cy.contains('31 December 2021');
+    cy.contains('01 January 2022');
     cy.contains('7202 11 80 00').click();
     cy.checkCommPage('7202118000');
     cy.go(-1);
@@ -71,7 +71,7 @@ describe('| GB-NI408a-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
     // values
     cy.contains('7202 11 80 00');
     cy.contains('Other');
-    cy.contains('31 December 2021');
+    cy.contains('01 January 2022');
     cy.contains('£10,002.24');
 
     // information
@@ -141,7 +141,7 @@ describe('| GB-NI408a-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
 
     //   cy.get('.govuk-summary-list__value')
     cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('1905 31 11 00');
-    cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('31 December 2021');
+    cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('01 January 2022');
     cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('Northern Ireland');
     cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
     cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('No');
@@ -154,7 +154,7 @@ describe('| GB-NI408a-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
     cy.contains('Import duty calculation');
     cy.contains('You are importing commodity');
     cy.contains('from United Kingdom (excluding Northern Ireland) on');
-    cy.contains('31 December 2021');
+    cy.contains('01 January 2022');
     cy.contains('Third-country duty (EU)');
     cy.contains('9.00 % + EA MAX 24.20 % +ADSZ');
     cy.contains('9.00 % + 0.00 EUR / 100 kg MAX 24.20 % + 0.00 EUR / 100 kg');

--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI408b-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI408b-e2e.spec.js
@@ -50,7 +50,7 @@ describe('| GB-NI408b-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
       cy.contains('Import quantity');
       //   cy.get('.govuk-summary-list__value')
       cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('1701 14 10 00');
-      cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('31 December 2021');
+      cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('01 January 2022');
       cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('Northern Ireland');
       cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
       cy.get('div:nth-of-type(6) > .govuk-summary-list__value').contains('No');
@@ -67,7 +67,7 @@ describe('| GB-NI408b-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
       cy.contains('Import duty calculation');
       cy.contains('You are importing commodity');
       cy.contains('from United Kingdom (excluding Northern Ireland) on');
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       cy.contains('1701 14 10 00').click();
       cy.checkCommPage('1701141000');
       cy.go(-1);
@@ -81,7 +81,7 @@ describe('| GB-NI408b-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
       // values
       cy.contains('1701 14 10 00');
       cy.contains('For refining');
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       cy.contains('£10,002.24');
 
       // information

--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI409a-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI409a-e2e.spec.js
@@ -47,7 +47,7 @@ describe('| GB-NI409a-e2e.spec | GB to NI route 🚌 09 - ✅  Trade Remedies |'
 
       //   Check values
       cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('0303 14 90 11');
-      cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('31 December 2021');
+      cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('01 January 2022');
       cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('Northern Ireland');
       cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
       cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('£5,785.87');

--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI409b-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI409b-e2e.spec.js
@@ -48,7 +48,7 @@ describe('| GB-NI409b-e2e.spec | GB to NI route 🚌 09 - ✅  Trade Remedies + 
       //   cy.contains('Import quantity')
       //   Check values
       cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('0304 82 90 10');
-      cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('31 December 2021');
+      cy.get('div:nth-of-type(2) > .govuk-summary-list__value').contains('01 January 2022');
       cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('Northern Ireland');
       cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
       cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('£5,785.87');

--- a/cypress/integration/DutyCalculator/dcShared/dcAdditionalCode.spec.js
+++ b/cypress/integration/DutyCalculator/dcShared/dcAdditionalCode.spec.js
@@ -20,7 +20,7 @@ describe('| dcAdditionalCode | RoW to GB - additional codes |', function() {
     cy.confirmPage();
     cy.dutyPage();
     cy.contains('You are importing commodity');
-    cy.contains('from Israel on 31 December 2021.');
+    cy.contains('from Israel on 01 January 2022.');
     cy.contains('6307 90 92 00 (2600)');
     cy.contains('Option 1: Third-country duty');
   });

--- a/cypress/integration/DutyCalculator/dcShared/dcConfirmPage.spec.js
+++ b/cypress/integration/DutyCalculator/dcShared/dcConfirmPage.spec.js
@@ -29,7 +29,7 @@ describe('🔖 | dcConfirmPage | UK Results Page |', function() {
     cy.contains('Import quantity');
     //   cy.get('.govuk-summary-list__value')
     cy.contains('1701 14 10 00');
-    cy.contains('31 December 2021');
+    cy.contains('01 January 2022');
     cy.contains('Northern Ireland');
     cy.contains('United Kingdom (excluding Northern Ireland');
     cy.contains('No');

--- a/cypress/integration/DutyCalculator/dcShared/dcDutyPage.spec.js
+++ b/cypress/integration/DutyCalculator/dcShared/dcDutyPage.spec.js
@@ -33,7 +33,7 @@ describe('🧮 | dcDutyPage | Duties Calculated - page |', function() {
     cy.contains('Import duty calculation');
     cy.contains('You are importing commodity');
     cy.contains('from United Kingdom (excluding Northern Ireland) on');
-    cy.contains('31 December 2021');
+    cy.contains('01 January 2022');
     cy.contains('7202 11 80 00').click();
     cy.checkCommPage('7202118000');
     cy.go(-1);
@@ -48,7 +48,7 @@ describe('🧮 | dcDutyPage | Duties Calculated - page |', function() {
     // values
     cy.contains('7202 11 80 00');
     cy.contains('Other');
-    cy.contains('31 December 2021');
+    cy.contains('01 January 2022');
     cy.contains('£10,002.24');
 
     // information

--- a/cypress/integration/DutyCalculator/dcShared/dcSmokeTestCI.spec.js
+++ b/cypress/integration/DutyCalculator/dcShared/dcSmokeTestCI.spec.js
@@ -153,7 +153,7 @@ describe('| dcSmokeTestCI.spec | Duty Calculator smoke test |', function() {
     cy.contains('Import quantity');
     //   cy.get('.govuk-summary-list__value')
     cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('1701 14 10 00');
-    cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('31 December 2021');
+    cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('01 January 2022');
     cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('Northern Ireland');
     cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
     cy.get('div:nth-of-type(6) > .govuk-summary-list__value').contains('Yes');

--- a/cypress/integration/HOTT-Shared/datePage.spec.js
+++ b/cypress/integration/HOTT-Shared/datePage.spec.js
@@ -6,7 +6,7 @@ describe('🇪🇺 💡 | datePage.spec.js | date page on Chapter , Heading and 
   for (let i = 0; i < country.length; i++) {
     it(`${country[i]} Commodity page `, function() {
       cy.visit(`${country[i]}/commodities/6406905010?day=31&month=12&year=2021`);
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       // Change date
       cy.get('div:nth-of-type(4) > .govuk-summary-list__actions > .govuk-link').click();
       console.log(cy.title());
@@ -16,7 +16,7 @@ describe('🇪🇺 💡 | datePage.spec.js | date page on Chapter , Heading and 
       // Cancel
       cy.get('.govuk-link').contains('Cancel').click();
       cy.contains('Commodity 6406905010');
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       // change date to future date
       cy.get('div:nth-of-type(4) > .govuk-summary-list__actions > .govuk-link').click();
       cy.datePickerPage({day: 22, month: 12, year: 2022});
@@ -28,7 +28,7 @@ describe('🇪🇺 💡 | datePage.spec.js | date page on Chapter , Heading and 
     });
     it(` ${country[i]} Heading page `, function() {
       cy.visit(`${country[i]}/headings/4302?day=31&month=12&year=2021`);
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       // Change date
       cy.get('.govuk-summary-list .govuk-link').click();
       cy.title().should('eq', `${titles[i]} - When will your goods be traded - GOV.UK`);
@@ -37,7 +37,7 @@ describe('🇪🇺 💡 | datePage.spec.js | date page on Chapter , Heading and 
       // Cancel
       cy.get('.govuk-link').contains('Cancel').click();
       cy.contains('Heading 4302');
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       // change date to future date
       cy.get('.govuk-summary-list .govuk-link').click();
       cy.datePickerPage({day: 22, month: 12, year: 2022});
@@ -49,7 +49,7 @@ describe('🇪🇺 💡 | datePage.spec.js | date page on Chapter , Heading and 
     });
     it(`${country[i]} Chapter page `, function() {
       cy.visit(`${country[i]}/chapters/43?day=31&month=12&year=2021`);
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       // Change date
       cy.get('.govuk-summary-list .govuk-link').click();
       cy.title().should('eq', `${titles[i]} - When will your goods be traded - GOV.UK`);
@@ -58,7 +58,7 @@ describe('🇪🇺 💡 | datePage.spec.js | date page on Chapter , Heading and 
       // Cancel
       cy.get('.govuk-link').contains('Cancel').click();
       cy.contains('Chapter 43 - Furskins and artificial fur; manufactures thereof');
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       // change date to future date
       cy.get('.govuk-summary-list .govuk-link').click();
       cy.datePickerPage({day: 22, month: 12, year: 2022});
@@ -70,7 +70,7 @@ describe('🇪🇺 💡 | datePage.spec.js | date page on Chapter , Heading and 
     });
     it(`${country[i]} Page validation `, function() {
       cy.visit(`${country[i]}/commodities/6406905010?day=31&month=12&year=2021`);
-      cy.contains('31 December 2021');
+      cy.contains('01 January 2022');
       // change date invalid
       cy.get('div:nth-of-type(4) > .govuk-summary-list__actions > .govuk-link').click();
       cy.datePickerPage({day: '00', month: '00', year: '0000'});

--- a/cypress/integration/HOTT-Shared/smokeTestTradeTariff.spec.js
+++ b/cypress/integration/HOTT-Shared/smokeTestTradeTariff.spec.js
@@ -191,7 +191,7 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
     cy.get('.tariff-info').contains('Quota order number');
     cy.get('.tariff-info').contains('057015');
     cy.get('.tariff-info').contains('Start and end dates');
-    cy.get('.tariff-info').contains('1 January 2021 to 31 December 2021');
+    cy.get('.tariff-info').contains('1 January 2021 to 01 January 2022');
     cy.get('.close [href]').click();
   });
   it(`🚀 UK 🇬🇧 - Mobile - nav-bar validation`, function() {
@@ -319,7 +319,7 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
 
     cy.contains(' Live animals; animal products');
     cy.get('.date-picker.datepicker.govuk-\\!-font-size-16.govuk-fieldset.govuk-form-group.inline.js-date-picker > .js-show.sections-context.text')
-        .contains('This tariff is for 31 December 2021');
+        .contains('This tariff is for 01 January 2022');
     cy.get('main#content  nav  a')
         .contains('Online Tariff').click();
     cy.contains('UK Integrated Online Tariff');
@@ -328,7 +328,7 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
         .click();
     cy.contains(' Live animals; animal products');
     cy.get('.date-picker.datepicker.govuk-\\!-font-size-16.govuk-fieldset.govuk-form-group.inline.js-date-picker > .js-show.sections-context.text')
-        .contains('This tariff is for 31 December 2021');
+        .contains('This tariff is for 01 January 2022');
   });
   it(`🚀 XI 🇪🇺 - Mobile - nav-bar validation`, function() {
     const sizes = ['iphone-6', 'samsung-note9'];

--- a/cypress/integration/UK/FE/quotasSearch-UK.spec.js
+++ b/cypress/integration/UK/FE/quotasSearch-UK.spec.js
@@ -17,7 +17,7 @@ describe('🇬🇧 💡 | quotasSearch-UK | QuotasSearch using comm codes and qu
       cy.contains('Quota 057015');
       cy.contains('057015');
       cy.contains('Start and end dates');
-      cy.contains('1 January 2021 to 31 December 2021');
+      cy.contains('1 January 2021 to 01 January 2022');
       cy.get('.close [href]').click();
     } else {}
   });

--- a/cypress/integration/UK/UKMobile/smokeTest-UK-M.spec.js
+++ b/cypress/integration/UK/UKMobile/smokeTest-UK-M.spec.js
@@ -226,7 +226,7 @@ describe.skip('🚀 📱 UK 🇬🇧 💡 | smokeTest-UK-M.spec | smoke test to 
     cy.contains('Quota order number');
     cy.contains('057015');
     cy.contains('Start and end dates');
-    cy.contains('1 January 2021 to 31 December 2021');
+    cy.contains('1 January 2021 to 01 January 2022');
     cy.get('.close [href]').click();
   });
 });


### PR DESCRIPTION
In view of comm code changes happening on 01st Jan 2022, Duty Cal date changed from 31-12-2021 t0 01-01-2022

- [ ] modified:   cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB201-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB202-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/2.RoW-GB/RoW-GB203-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI303a-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI307-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/3.RoW-NI/RoW-NI308-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/4.GB-NI/GB-NI404-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/4.GB-NI/GB-NI406-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/4.GB-NI/GB-NI408a-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/4.GB-NI/GB-NI408b-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/4.GB-NI/GB-NI409a-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/4.GB-NI/GB-NI409b-e2e.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/dcShared/dcAdditionalCode.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/dcShared/dcConfirmPage.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/dcShared/dcDutyPage.spec.js
- [ ] 	modified:   cypress/integration/DutyCalculator/dcShared/dcSmokeTestCI.spec.js
- [ ] 	modified:   cypress/integration/HOTT-Shared/datePage.spec.js
- [ ] 	modified:   cypress/integration/HOTT-Shared/smokeTestTradeTariff.spec.js
- [ ] 	modified:   cypress/integration/UK/FE/quotasSearch-UK.spec.js
- [ ] 	modified:   cypress/integration/UK/UKMobile/smokeTest-UK-M.spec.js