### PR TITLE
Adjusts cron schedule for staging regression

### DIFF
--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -2,13 +2,13 @@ name: "| Staging | Regression Pack |"
 
 on:
   schedule:
-    - cron: "00 05 * * *"
+    - cron: "45 06 * * *"
   workflow_dispatch:
 
 jobs:
   cypress-run:
     env:
-      CYPRESS_BASE_URL: 'https://staging.trade-tariff.service.gov.uk'
+      CYPRESS_BASE_URL: "https://staging.trade-tariff.service.gov.uk"
     name: " 🛎️ Regression Tests - UK and XI - Staging "
     runs-on: ubuntu-18.04
     strategy:
@@ -27,7 +27,7 @@ jobs:
         with:
           quiet: true
           browser: chrome
-          headless: true       
+          headless: true
           spec: "*/**/**/*spec.js"
 
       - run: npm run posttests
@@ -69,9 +69,9 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: ${{ steps.cypress.outcome == 'failure' }}
         env:
-          SLACK_USERNAME: 'Staging Regression'
+          SLACK_USERNAME: "Staging Regression"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_ICON_EMOJI: ':alphabet-yellow-s:'
+          SLACK_ICON_EMOJI: ":alphabet-yellow-s:"
           SLACK_COLOR: ${{ job.status }}
           SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
           SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/staging/${{ steps.date.outputs.date }}/
@@ -87,10 +87,7 @@ jobs:
         name: " Cypress Dashboard "
         continue-on-error: true
         with:
-          record: true    
+          record: true
           spec: "*/*/*/cypressDashTest.spec.js"
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.RECORD_KEY }}
-
-
-     


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1237

### What?

I have added/removed/altered:

- [x] Updated the staging regression schedule to reflect the ETL job
- [x] Removed dead whitespace from the workflow file

### Why?

I am doing this because:

- We've recently changed the schedule of ETL on dev, staging and
production so these regression tests are reflecting the cached responses
of the previous day and could miss current data.
