### PR TITLE
Move notifications to tariffs-regression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ workflows:
             - store_artifacts:
                 path: cypress/reports
             - slack/notify:
-                channel: tariffs-etl
+                channel: tariffs-regression
                 event: fail
                 template: basic_fail_1
             - slack/notify:
-                channel: tariffs-etl
+                channel: tariffs-regression
                 event: pass
                 custom: |
                   {
@@ -76,11 +76,11 @@ workflows:
             - store_artifacts:
                 path: cypress/reports
             - slack/notify:
-                channel: tariffs-etl
+                channel: tariffs-regression
                 event: fail
                 template: basic_fail_1
             - slack/notify:
-                channel: tariffs-etl
+                channel: tariffs-regression
                 event: pass
                 custom: |
                   {

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cypress-run:
     env:
-      CYPRESS_BASE_URL: 'https://www.trade-tariff.service.gov.uk'
+      CYPRESS_BASE_URL: "https://www.trade-tariff.service.gov.uk"
     name: "🚦 Regression Tests - UK and XI"
     runs-on: ubuntu-18.04
     strategy:
@@ -25,7 +25,7 @@ jobs:
         with:
           quiet: true
           browser: chrome
-          headless: true       
+          headless: true
           spec: "*/**/**/*spec.js"
 
       - run: npm run posttests
@@ -66,13 +66,13 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: ${{ steps.cypress.outcome == 'failure' }}
         env:
-          SLACK_USERNAME: 'Production Regression'
+          SLACK_CHANNEL: "tariffs-regression"
+          SLACK_USERNAME: "Production Regression"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}
-          SLACK_ICON_EMOJI: ':alphabet-yellow-p:'
+          SLACK_ICON_EMOJI: ":alphabet-yellow-p:"
           SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
           SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/${{ steps.date.outputs.date }}/
-
 
       - name: Push changes
         uses: ad-m/github-push-action@master
@@ -85,9 +85,7 @@ jobs:
         name: " Cypress Dashboard "
         continue-on-error: true
         with:
-          record: true    
+          record: true
           spec: "*/*/*/cypressDashTest.spec.js"
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.RECORD_KEY }}
-
-     

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -69,6 +69,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         if: ${{ steps.cypress.outcome == 'failure' }}
         env:
+          SLACK_CHANNEL: 'tariffs-regression'
           SLACK_USERNAME: "Staging Regression"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":alphabet-yellow-s:"


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Altered slack channel for circle ci and github workflow pipelines to `tariffs-regression`
- [x] Linted

### Why?

I am doing this because:

- This is to remove noise around actual ETL notifications which we are in the process of expanding
