### PR TITLE
Added command for running cypress against review app

### DIFF
--- a/bin/cypress-review-app.sh
+++ b/bin/cypress-review-app.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -z ${1} ]; then
+  echo "No Pull Request number supplied"
+  exit 1
+fi
+
+CYPRESS_BASE_URL="https://tariff-frontend-pr${1}.london.cloudapps.digital" npx cypress open

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "open:prod": "CYPRESS_BASE_URL=https://www.trade-tariff.service.gov.uk npx cypress open",
     "open:localhost": "CYPRESS_BASE_URL=http://localhost:3001 npx cypress open",
     "tags:roo": "CYPRESS_BASE_URL=https://staging.trade-tariff.service.gov.uk yarn run cypress run --env=grepTags=roo-tag,grepFilterSpecs=true",
-    "open:reviewapps": "CYPRESS_BASE_URL=https://tariff-frontend-pr583.london.cloudapps.digital npx cypress open"
+    "open:reviewapp": "bin/cypress-review-app.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cypress can be launched against a review app for a particular pull request with

```
yarn run open:reviewapp PR_NUMBER
```

eg

```
yarn run open:reviewapp 586
```