### PR TITLE
Improve nightly ci run reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@1.27.0
+  cypress: cypress-io/cypress@1.29.0
   slack: circleci/slack@4.1
 
 executors: # This is totally crazy but it's the only way to configure the environment: https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-env-vars

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ orbs:
   slack: circleci/slack@4.1
 
 executors: # This is totally crazy but it's the only way to configure the environment: https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-env-vars
-  custom_chrome94:
+  custom_chrome:
     docker:
-      - image: 'cypress/browsers:node16.5.0-chrome94-ff93'
+      - image: 'cypress/browsers:node16.13.2-chrome97-ff96'
     environment:
       CYPRESS_BASE_URL: "https://staging.trade-tariff.service.gov.uk"
 
@@ -14,7 +14,7 @@ workflows:
   debug:
     jobs:
       - cypress/run:
-          executor: custom_chrome94
+          executor: custom_chrome
           context: trade-tariff
           name: "🚀 UK XI & DC Smoke tests"
           browser: chrome
@@ -63,7 +63,7 @@ workflows:
                 - main
     jobs:
       - cypress/run:
-          executor: custom_chrome94
+          executor: custom_chrome
           context: trade-tariff
           name: "🚀 Tariff & DC Smoke tests scheduled - Staging"
           browser: chrome

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ workflows:
           store_artifacts: true
           spec: "*/**/smokeTestCI.spec.js"
           yarn: true
+          config: 'defaultCommandTimeout=25000'
           post-steps:
             - store_test_results:
                 path: cypress/results


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Increased the timeout for accessing pages
- [x] Upgrade the version of Chrome to 97
- [x] Upgraded the version of the orb used

### Why?

I am doing this because:

- We are seeing occasional failures from slow pages
