### PR TITLE
HOTT-1540: Updates kilogrammes to kilograms to reflect DC changes

### DIFF
--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI404-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI404-e2e.spec.js
@@ -66,7 +66,7 @@ describe('| GB-NI404-e2e.spec | GB to NI route 🚐 04  - 🚫 Trade Remedies - 
       cy.get('div:nth-of-type(8) > .govuk-summary-list__value').contains('No');
       cy.get('div:nth-of-type(9) > .govuk-summary-list__value').contains('£10,002.24');
       // cy.contains('12.50 x 100 kg')
-      cy.contains('2300.98 kilogrammes');
+      cy.contains('2300.98 kilograms');
       // cy.contains('72.56 tonnes')
       // cy.contains('87.25 x 10,000 kg')
       cy.get('.govuk-button').click();

--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI406-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI406-e2e.spec.js
@@ -69,7 +69,7 @@ describe('| GB-NI406-e2e.spec | EU Duties apply | GB to NI route 06 - 🚫 Trade
       cy.get('div:nth-of-type(10) > .govuk-summary-list__value').contains('No');
       cy.get('div:nth-of-type(11) > .govuk-summary-list__value').contains('£10,002.24');
 
-      cy.contains('2398 kilogrammes');
+      cy.contains('2398 kilograms');
 
       cy.get('.govuk-button').click();
 

--- a/cypress/integration/DutyCalculator/4.GB-NI/GB-NI408b-e2e.spec.js
+++ b/cypress/integration/DutyCalculator/4.GB-NI/GB-NI408b-e2e.spec.js
@@ -54,7 +54,7 @@ describe('| GB-NI408b-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
       cy.get('div:nth-of-type(6) > .govuk-summary-list__value').contains('No');
       cy.get('div:nth-of-type(7) > .govuk-summary-list__value').contains('No');
       cy.get('div:nth-of-type(8) > .govuk-summary-list__value').contains('£10,002.24');
-      cy.contains('23098 kilogrammes');
+      cy.contains('23098 kilograms');
       // confirm
       cy.get('.govuk-button').click();
 
@@ -92,7 +92,7 @@ describe('| GB-NI408b-e2e.spec | GB to NI route 🚐 08 - 🚫 Trade Remedies - 
       // import duty
       cy.contains('Import duty Third-country duty (EU)');
       cy.contains('Import quantity');
-      cy.contains('230.98 kilogrammes');
+      cy.contains('230.98 kilograms');
       cy.contains('33.90 EUR / 100 kg std qual * 230.98');
 
       cy.contains('Duty Total');

--- a/cypress/integration/DutyCalculator/dcShared/dcMeasureAmount.spec.js
+++ b/cypress/integration/DutyCalculator/dcShared/dcMeasureAmount.spec.js
@@ -10,7 +10,7 @@ describe('🧮 | dcMeasureAmount.spec | Measure Amount - page |', function() {
     cy.contains('Enter import quantity');
     cy.contains('The duties payable on this commodity are dependent on the quantity, weight or volume of goods that you are importing. Enter the units of the goods that you are importing in the boxes below.');
     cy.contains('What is the weight net of the standard quality of the goods you will be importing?');
-    cy.contains('Enter the value in kilogrammes');
+    cy.contains('Enter the value in kilograms');
     cy.contains('Enter the value in tonnes (1,000 kg)');
     cy.contains('Enter the value in decatonnes (10,000 kg), corrected according to polarisation');
     // explore this topic
@@ -24,7 +24,7 @@ describe('🧮 | dcMeasureAmount.spec | Measure Amount - page |', function() {
     cy.contains('Continue').click();
     cy.get('.govuk-error-summary');
     cy.contains('There is a problem');
-    cy.contains('Enter a valid import quantity. Enter the value in kilogrammes');
+    cy.contains('Enter a valid import quantity. Enter the value in kilograms');
     cy.contains('Enter a valid import quantity. Enter the value in tonnes (1,000 kg)');
     cy.contains('Enter a valid import quantity. Enter the value in decatonnes (10,000 kg), corrected according to polarisation');
     cy.get('.govuk-back-link').click();
@@ -33,7 +33,7 @@ describe('🧮 | dcMeasureAmount.spec | Measure Amount - page |', function() {
     cy.quantity({tne: 'aaaa', dtnr: 'jjjj', dap: 'bbbb'});
     cy.contains('Continue').click();
     cy.get('.govuk-error-summary').contains('There is a problem');
-    cy.contains('Enter a numeric import quantity. Enter the value in kilogrammes');
+    cy.contains('Enter a numeric import quantity. Enter the value in kilograms');
     cy.contains('Enter a numeric import quantity. Enter the value in tonnes (1,000 kg)');
     cy.contains('Enter a numeric import quantity. Enter the value in decatonnes (10,000 kg), corrected according to polarisation');
     cy.get('.govuk-back-link').click();
@@ -42,7 +42,7 @@ describe('🧮 | dcMeasureAmount.spec | Measure Amount - page |', function() {
     cy.quantity({tne: -999, dtnr: -888, dap: -4.989});
     cy.contains('Continue').click();
     cy.get('.govuk-error-summary').contains('There is a problem');
-    cy.contains('Enter an import quantity value greater than zero. Enter the value in kilogrammes');
+    cy.contains('Enter an import quantity value greater than zero. Enter the value in kilograms');
     cy.contains('Enter an import quantity value greater than zero. Enter the value in tonnes (1,000 kg)');
     cy.contains('Enter an import quantity value greater than zero. Enter the value in decatonnes (10,000 kg), corrected according to polarisation');
     cy.get('.govuk-back-link').click();

--- a/cypress/integration/DutyCalculator/dcShared/dcSmokeTestCI.spec.js
+++ b/cypress/integration/DutyCalculator/dcShared/dcSmokeTestCI.spec.js
@@ -31,7 +31,7 @@ describe('| dcSmokeTestCI.spec | Duty Calculator smoke test |', function() {
   it(`🚀 UK 🇬🇧 Duty Calculator - RoW to GB 🇦🇫 Afghanistan to 🇬🇧 GB | 204 |`, function() {
     // select future date
     cy.visit(`/duty-calculator/uk/3926909790/import-date`);
-    
+
     cy.validDate();
     cy.selectDestination('gb');
     cy.originList({value: 'Afghanistan'});
@@ -51,7 +51,7 @@ describe('| dcSmokeTestCI.spec | Duty Calculator smoke test |', function() {
     cy.contains('Option 4: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
     cy.contains('Option 3: Airworthiness tariff suspension');
   });
-  it.only('🚀 XI 🇪🇺 - Duty Calculator e2e - RoW 🇦🇩 (Andorra) - XI 304i | UK Tariffs apply with Meursing code 7000 ,EU Tariffs apply with Meursing code 7049 |', function() {
+  it('🚀 XI 🇪🇺 - Duty Calculator e2e - RoW 🇦🇩 (Andorra) - XI 304i | UK Tariffs apply with Meursing code 7000 ,EU Tariffs apply with Meursing code 7049 |', function() {
     cy.visit('/duty-calculator/xi/1905311100/import-date');
     // date
     cy.validDate();
@@ -105,7 +105,7 @@ describe('| dcSmokeTestCI.spec | Duty Calculator smoke test |', function() {
     cy.contains('9.00 % + EA MAX 24.20 % +ADSZ');
   });
 
-  it.only(`🚀 XI 🇪🇺 - Duty Calculator e2e - ( GB to NI ) | 406 |`, function() {
+  it(`🚀 XI 🇪🇺 - Duty Calculator e2e - ( GB to NI ) | 406 |`, function() {
     cy.visit('/duty-calculator/xi/1701141000/import-date');
 
     cy.validDate();
@@ -158,7 +158,7 @@ describe('| dcSmokeTestCI.spec | Duty Calculator smoke test |', function() {
     cy.get('div:nth-of-type(10) > .govuk-summary-list__value').contains('No');
     cy.get('div:nth-of-type(11) > .govuk-summary-list__value').contains('£10,002.24');
 
-    cy.contains('23.98 kilogrammes');
+    cy.contains('23.98 kilograms');
     cy.get('.govuk-button').click();
 
     // Final Page


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1540

### What?

I have added/removed/altered:

- [x] Updated all measure amount references in kilogrammes to use the American spelling kilograms

### Why?

I am doing this because:

- This is something that has been changed in the backend
- The smoke tests won't pass against dev until this is updated

See also:

- https://github.com/trade-tariff/trade-tariff-backend/pull/556
- https://github.com/trade-tariff/trade-tariff-duty-calculator/pull/474
