### PR TITLE
Tidy home path and some selectors

### DIFF
--- a/cypress/integration/DutyCalculator/dcShared/dcImportDate.spec.js
+++ b/cypress/integration/DutyCalculator/dcShared/dcImportDate.spec.js
@@ -86,12 +86,12 @@ describe('🧮 📅 | dcImportDate | Duty Calculator main page |', function() {
       cy.contains('A-Z').click();
       cy.reload();
       cy.contains('A–Z of Classified Goods');
-      cy.get('.govuk-header ').contains(`${pagetitles[i]}`);
+      cy.get('.govuk-header').contains(`${pagetitles[i]}`);
       // DC main page
       cy.visit(`duty-calculator/${country[i]}/0702000007/import-date`);
       cy.contains(`${pagetitles[i]}`);
       cy.contains('Tools').click();
-      cy.get('.govuk-header ').contains(`${pagetitles[i]}`);
+      cy.get('.govuk-header').contains(`${pagetitles[i]}`);
       cy.contains('Tariff tools');
     });
     it(`🔖 Commodity Details ${country[i]}`, function() {
@@ -114,7 +114,7 @@ describe('🧮 📅 | dcImportDate | Duty Calculator main page |', function() {
       cy.contains('View commodity 0702000007').click();
       // ☀️ Validate commodity page
       cy.checkCommPage('0702000007');
-      cy.get('.govuk-header ').contains(`${pagetitles[i]}`);
+      cy.get('.govuk-header').contains(`${pagetitles[i]}`);
       cy.go(-1);
       cy.contains('When will the goods be imported?');
       cy.contains(`${pagetitles[i]}`);

--- a/cypress/integration/HOTT-Shared/changeCurrency-UKXI.spec.js
+++ b/cypress/integration/HOTT-Shared/changeCurrency-UKXI.spec.js
@@ -1,7 +1,7 @@
 describe('🇬🇧 🇪🇺 💡 | changeCurrency-UK XI | Change Currency should not be visible  -  UK services |', function() {
   // --- HOTT-161 ---
   it('UK - Change Currency should not be visible on main page - The Online Trade Tariff', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.mainPageUK();
     cy.get('.govuk-grid-row');
     cy.contains('Change currency').should('not.exist');

--- a/cypress/integration/HOTT-Shared/devSmokeTestCI.spec.js
+++ b/cypress/integration/HOTT-Shared/devSmokeTestCI.spec.js
@@ -2,7 +2,7 @@
 describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke tests for dev |', function() {
   // Main Page
   it('🚀 UK 🇬🇧 - Main Page Validation', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.mainPageUK();
     cy.contains('browse the goods classification').click();
     cy.contains('Browse the tariff');
@@ -10,7 +10,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
   // Date Picker validation
   it('🚀 UK 🇬🇧 - Check date picker function is working', function() {
     cy.visit('/find_commodity');
-    
+
     // select Change Date and OK with current date
     cy.get('.govuk-details__summary').click();
     cy.get('#tariff_date_day').click().clear().type(21);
@@ -22,22 +22,22 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
     // select Change Date and CANCEL
     // cy.get(' .js-show.text > a[role=\'button\']').click();
     // cy.contains('Set date').click();
-    // 
+    //
 
     // select Change Date and change months and years
     cy.get('div:nth-of-type(4) > .govuk-summary-list__actions > .govuk-link').click();
     cy.datePickerPage({day: 22, month: 12, year: 2022});
-    
+
     cy.contains('22 December 2022');
   });
   // switching link works
   it.only('🚀 UK 🇬🇧 - Main Page - Switching link to XI available & works', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
-        .contains('Northern Ireland Online Tariff')
+      .contains('Northern Ireland Online Tariff', {"timeout": 2000})
         .click();
     cy.get('header.govuk-header div.govuk-header__container div.govuk-header__content')
         .contains('Northern Ireland Online Tariff');
@@ -53,7 +53,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
   });
   // Commodity Search functionality - text search
   it('🚀 UK 🇬🇧 - Search Commodity by name ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.contains('Search for a commodity');
     // changed on 11/02/2021
     cy.get('.govuk-label').contains('Search the UK Integrated Online Tariff');
@@ -62,7 +62,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
   });
   // Commodity Search functionality - comm code search
   it('🚀 UK 🇬🇧 - Search Commodity by code ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.contains('Look up commodity codes, import duties, taxes and controls'); ;
     cy.contains('Search for a commodity');
     cy.searchForCommodity('3808941000');
@@ -71,7 +71,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
 
   // Date picker working and persists on UK XI sites
   it('🚀 UK 🇬🇧 / XI 🇪🇺 - Change date and verify if the data shown is same for both XI and UK', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     // select Change Date and change months and years
     cy.get('.govuk-details__summary').click();
     cy.get('#tariff_date_day').click().clear().type(21);
@@ -80,7 +80,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
     cy.searchForCommodity('3808941000');
     cy.get('.govuk-heading-l.commodity-header').contains(/Commodity .*3808941000/i);
     // cy.contains('Set date').click();
-    // 
+    //
     cy.contains('21 December 2021');
     // switch to XI tariff
     cy.contains('Northern Ireland Online Tariff').click();
@@ -101,7 +101,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
   });
   it('🚀 XI 🇪🇺 - Check Calendar is functioning', function() {
     cy.visit('/xi/sections');
-    
+
     // select Change Date and OK with current date
     cy.get('.govuk-details__summary').click();
     cy.get('#tariff_date_day').click().clear().type(21);
@@ -113,12 +113,12 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
     // select Change Date and CANCEL
     // cy.get(' .js-show.text > a[role=\'button\']').click();
     // cy.contains('Set date').click();
-    // 
+    //
 
     // select Change Date and change months and years
     cy.get('div:nth-of-type(4) > .govuk-summary-list__actions > .govuk-link').click();
     cy.datePickerPage({day: 22, month: 12, year: 2022});
-    
+
     cy.contains('22 December 2022');
   });
   // switching link works

--- a/cypress/integration/HOTT-Shared/devSmokeTestCI.spec.js
+++ b/cypress/integration/HOTT-Shared/devSmokeTestCI.spec.js
@@ -31,25 +31,25 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
     cy.contains('22 December 2022');
   });
   // switching link works
-  it('🚀 UK 🇬🇧 - Main Page - Switching link to XI available & works', function() {
+  it.only('🚀 UK 🇬🇧 - Main Page - Switching link to XI available & works', function() {
     cy.visit('/sections');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('header.govuk-header div.govuk-header__container div.govuk-header__content')
         .contains('Northern Ireland Online Tariff');
 
     // click on the XI link and it should navigate to XI version
-    cy.get('.govuk-main-wrapper');
-    cy.contains('UK Integrated Online Tariff')
-        .click();
-    cy.get('.govuk-header ')
-        .contains('UK Integrated Online Tariff');
-    cy.get('.govuk-main-wrapper')
-        .contains('Northern Ireland Online Tariff');
+    // cy.get('.govuk-main-wrapper');
+    // cy.contains('UK Integrated Online Tariff')
+    //     .click();
+    // cy.get('.govuk-header')
+    //     .contains('UK Integrated Online Tariff');
+    // cy.get('.govuk-main-wrapper')
+    //     .contains('Northern Ireland Online Tariff');
   });
   // Commodity Search functionality - text search
   it('🚀 UK 🇬🇧 - Search Commodity by name ', function() {
@@ -124,19 +124,19 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | devSmokeTestCI- UK,XI| Smoke test
   // switching link works
   it('🚀 XI 🇪🇺 - Main Page - Switching link to UK available & works', function() {
     cy.visit('/xi/sections');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // click on the UK link and it should navigate to UK version
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');

--- a/cypress/integration/HOTT-Shared/smokeTestCI.spec.js
+++ b/cypress/integration/HOTT-Shared/smokeTestCI.spec.js
@@ -3,7 +3,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | smokeTestCI- UK,XI & DC | Smoke t
   // ************ UK tests ************
   // Main Page
   it('🚀 UK 🇬🇧 - Main Page Validation', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.mainPageUK();
   });
   // Date Picker validation
@@ -27,7 +27,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | smokeTestCI- UK,XI & DC | Smoke t
   });
   // switching link works
   it('🚀 UK 🇬🇧 - Main Page - Switching link to XI available & works', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
@@ -79,7 +79,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | smokeTestCI- UK,XI & DC | Smoke t
   });
   // Commodity Search functionality - text search
   it('🚀 UK 🇬🇧 - Search Commodity by name ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.contains('Search for a commodity');
     // changed on 11/02/2021
     cy.get('.govuk-label').contains('Search the UK Integrated Online Tariff');
@@ -88,7 +88,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | smokeTestCI- UK,XI & DC | Smoke t
   });
   // Commodity Search functionality - comm code search
   it('🚀 UK 🇬🇧 - Search Commodity by code ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.contains('Look up commodity codes, import duties, taxes and controls'); ;
     cy.contains('Search for a commodity');
     cy.searchForCommodity('3808941000');
@@ -171,7 +171,7 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | smokeTestCI- UK,XI & DC | Smoke t
     for (let i = 0; i < sizes.length; i++) {
       cy.viewport(`${sizes[i]}`);
 
-      cy.visit('/sections');
+      cy.visit('/find_commodity');
       cy.get('.govuk-header').should('be.visible', 'UK Integrated Online Tariff');
       cy.get('.govuk-header__menu-button').click();
       cy.contains('A-Z').click();

--- a/cypress/integration/HOTT-Shared/smokeTestCI.spec.js
+++ b/cypress/integration/HOTT-Shared/smokeTestCI.spec.js
@@ -28,20 +28,20 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | smokeTestCI- UK,XI & DC | Smoke t
   // switching link works
   it('🚀 UK 🇬🇧 - Main Page - Switching link to XI available & works', function() {
     cy.visit('/sections');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
@@ -233,19 +233,19 @@ describe('🚀  UK 🇬🇧 XI 🇪🇺 💡 | smokeTestCI- UK,XI & DC | Smoke t
   // switching link works
   it('🚀 XI 🇪🇺 - Main Page - Switching link to UK available & works', function() {
     cy.visit('/xi/sections');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // click on the UK link and it should navigate to UK version
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');

--- a/cypress/integration/HOTT-Shared/smokeTestTradeTariff.spec.js
+++ b/cypress/integration/HOTT-Shared/smokeTestTradeTariff.spec.js
@@ -2,12 +2,12 @@
 describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke tests for UK & XI services |', function() {
   // Main Page
   it('🚀 UK 🇬🇧 - Main Page Validation', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.mainPageUK();
   });
   // switching link works
   it('🚀 UK 🇬🇧 - Main Page - Switching link to XI available & works', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
@@ -62,7 +62,7 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
   });
   // Commodity Search functionality - text search
   it('🚀 UK 🇬🇧 - Search Commodity by name ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     // changed on 11/02/2021
     // cy.contains('Look up commodity codes, duty and VAT rates');;
     // changed on 11/02/2021
@@ -72,7 +72,7 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
 
   // Commodity Search functionality - comm code search
   it('🚀 UK 🇬🇧 - Search Commodity by code ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     // cy.contains('Look up commodity codes, duty and VAT rates');;
     cy.searchForCommodity('3808941000');
     cy.checkCommPage('3808941000');
@@ -127,7 +127,7 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
   });
   // Date picker working and persists on UK XI sites
   it('🚀 UK 🇬🇧 - (past date) Change date and verify if the data shown is same for both XI and UK', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
 
     // select Change Date and change months and years
     cy.get(' .js-show.text > a[role=\'button\']').click();
@@ -200,7 +200,7 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
     for (let i = 0; i < sizes.length; i++) {
       cy.viewport(`${sizes[i]}`);
 
-      cy.visit('/sections');
+      cy.visit('/find_commodity');
       cy.get('.govuk-header').should('be.visible', 'UK Integrated Online Tariff');
       cy.get('.govuk-header__menu-button').click();
       cy.contains('A-Z');

--- a/cypress/integration/HOTT-Shared/smokeTestTradeTariff.spec.js
+++ b/cypress/integration/HOTT-Shared/smokeTestTradeTariff.spec.js
@@ -8,20 +8,20 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
   // switching link works
   it('🚀 UK 🇬🇧 - Main Page - Switching link to XI available & works', function() {
     cy.visit('/sections');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
@@ -218,19 +218,19 @@ describe.skip('🚀 | smokeTestTradeTariff.spec.js |UK & XI | Front end - Smoke 
   // switching link works
   it('🚀 XI 🇪🇺 - Main Page - Switching link to UK available & works', function() {
     cy.visit('/xi/sections');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // click on the UK link and it should navigate to UK version
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');

--- a/cypress/integration/HOTT-Shared/testExample.spec.js
+++ b/cypress/integration/HOTT-Shared/testExample.spec.js
@@ -12,7 +12,7 @@ describe.skip('test spec - mini tests', {tags: 'miniTestTag'}, function() {
     //  cy.contains(`Commodity ${headings[j]}`+ '000000');
   });
   it('mainpage', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     console.log(cy.title());
     cy.visit('/chapters/01');
     console.log(cy.title());
@@ -44,7 +44,7 @@ describe.skip('test spec - mini tests', {tags: 'miniTestTag'}, function() {
     Helpers.sayHello('Madhu');
   });
   it('new main page', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.commPage();
     cy.newsBannerUK();
     cy.visit('xi/sections');
@@ -57,7 +57,7 @@ describe.skip('test spec - mini tests', {tags: 'miniTestTag'}, function() {
     cy.contextSelector();
   });
   it('page titles', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     console.log(cy.title());
     cy.visit('/browse');
     console.log(cy.title());

--- a/cypress/integration/SwitchingLinks-XI/SwitchingLinks-XI.js
+++ b/cypress/integration/SwitchingLinks-XI/SwitchingLinks-XI.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 Given('I am on XI Trade Tariff main page', ()=>{
   cy.visit('/xi/sections');
-  cy.get('.govuk-header ')
+  cy.get('.govuk-header')
       .contains('Northern Ireland Online Tariff');
   cy.get('.tariff-breadcrumbs')
       .should('have.text', 'If you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate if your goods are not ‘at risk’ of onward movement to the EU. If they are not at risk of onward movement to the EU, use the Online Tariff.');
@@ -12,7 +12,7 @@ When('I click on switch link on XI page', ()=>{
 });
 
 Then('UK version of Trade Tariff page is displayed', ()=>{
-  cy.get('.govuk-header ')
+  cy.get('.govuk-header')
       .contains('The Online Trade Tariff');
   cy.get('.tariff-breadcrumbs')
       .should('have.text', 'If you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate if your goods are not ‘at risk’ of onward movement to the EU. If they are at risk of onward movement to the EU, use the Northern Ireland (EU) Tariff.');
@@ -25,7 +25,7 @@ When('I click on switch link on UK page', ()=>{
 
 
 Then('XI version of Trade Tariff page is displayed', ()=>{
-  cy.get('.govuk-header ')
+  cy.get('.govuk-header')
       .contains('Northern Ireland Online Tariff');
   cy.get('.tariff-breadcrumbs ')
       .should('have.text', 'If you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate if your goods are not ‘at risk’ of onward movement to the EU. If they are not at risk of onward movement to the EU, use the UK Integrated Online Tariff.');

--- a/cypress/integration/UK/FE/e2eMozzarellaChile-UK.spec.js
+++ b/cypress/integration/UK/FE/e2eMozzarellaChile-UK.spec.js
@@ -1,6 +1,6 @@
 describe('🇬🇧 💡 | e2eMozzarellaChile-UK | importing Mozzarella 🧀  from Chile 🇨🇱 |', function() {
   it('Search and import cheese from Chile ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     // cy.contains('Look up commodity codes, duty and VAT rates');;
     cy.searchForCommodity('0406103010');
     cy.title().should('contains', '0406103010');

--- a/cypress/integration/UK/FE/feedback-UK.spec.js
+++ b/cypress/integration/UK/FE/feedback-UK.spec.js
@@ -18,7 +18,7 @@ describe('🇬🇧 💡 | feedback-UK | feedback link is available and user is a
   });
 
   it('UK - Feedback link works - Edge cases ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__navigation');
     cy.contains('Feedback')
         .click();
@@ -69,7 +69,7 @@ describe('🇬🇧 💡 | feedback-UK | feedback link is available and user is a
     cy.contains('Look up commodity codes, import duties, taxes and controls');
   });
   it('UK - The UK has left the EU', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__row');
     cy.contains('The UK has left the EU');
   });

--- a/cypress/integration/UK/FE/newTerminatedCommCodes-UK.spec.js
+++ b/cypress/integration/UK/FE/newTerminatedCommCodes-UK.spec.js
@@ -5,7 +5,7 @@ describe(' 🇬🇧 💡 | newTerminatedCommCodes-UK | New ,Terminated comm code
     const termcodes_ids = Cypress.config('termcodes');
 
     for (let i = 0; i < termcodes_ids.length; i++) {
-      cy.visit('/sections');
+      cy.visit('/find_commodity');
       cy.searchForCommodity(`${termcodes_ids[i]}`);
       cy.contains('The commodity code you entered could not be found for the date selected. The code is present for the dates shown below.');
     }
@@ -15,7 +15,7 @@ describe(' 🇬🇧 💡 | newTerminatedCommCodes-UK | New ,Terminated comm code
     const newcodes_ids = Cypress.config('newcodes');
 
     for (let i = 0; i < newcodes_ids.length; i++) {
-      cy.visit('/sections');
+      cy.visit('/find_commodity');
       cy.searchForCommodity(`${newcodes_ids[i]}`);
       cy.checkCommPage(`${newcodes_ids[i]}`);
     }

--- a/cypress/integration/UK/FE/pageLinks-UK.spec.js
+++ b/cypress/integration/UK/FE/pageLinks-UK.spec.js
@@ -4,7 +4,7 @@ describe(' 🇬🇧 💡 | pageLinks-UK | Terms and Conditions, Cookies ,Privacy
 
   // Support Links
   it('UK - Support links - Terms and Conditions -UK', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__inline-list > li:nth-of-type(3) > .govuk-footer__link')
         .contains('Terms and conditions').click();
     console.log(cy.title());
@@ -25,7 +25,7 @@ describe(' 🇬🇧 💡 | pageLinks-UK | Terms and Conditions, Cookies ,Privacy
   });
 
   it('UK - Support links - Cookies-navigates to right UK page ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__inline-list > li:nth-of-type(2) > .govuk-footer__link')
         .contains('Cookies').click();
     cy.title().should('matches', /UK Integrated Online Tariff: look up commodity codes, duty and VAT rates - GOV.UK/i);
@@ -33,7 +33,7 @@ describe(' 🇬🇧 💡 | pageLinks-UK | Terms and Conditions, Cookies ,Privacy
         .contains('Cookies');
   });
   it('UK - Support links - Privacy -navigates to right UK page', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__inline-list > li:nth-of-type(1) > .govuk-footer__link')
         .contains('Privacy').click();
     cy.contains('Privacy notice');
@@ -43,26 +43,26 @@ describe(' 🇬🇧 💡 | pageLinks-UK | Terms and Conditions, Cookies ,Privacy
 
   // The UK has left the EU
   it('UK - The UK has left the EU - Check the new rules for January 2021 ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.contains('The UK has left the EU');
     cy.contains('Check the new rules for January 2021');
     cy.get('.govuk-footer__navigation .govuk-footer__row:nth-of-type(1) [target]').should('have.attr', 'href', 'https://www.gov.uk/transition'); // no page load!
   });
 
   it('UK - Contact - Ask HMRC for advice on classifying your goods', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('Ask HMRC for advice on classifying your goods');
     cy.get('.govuk-\\!-margin-top-5.govuk-footer__row > div:nth-of-type(1) > .govuk-footer__list > li:nth-of-type(1) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods'); // no page load!
   });
   it('UK - Contact - Imports and exports: general enquiries', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('Imports and exports: general enquiries');
     cy.get('.govuk-\\!-margin-top-5.govuk-footer__row > div:nth-of-type(1) > .govuk-footer__list > li:nth-of-type(2) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries'); // no page load!
   });
   it('UK - Contact - Feedback', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('Feedback');
     cy.get('.govuk-\\!-margin-top-5.govuk-footer__row > div:nth-of-type(1) > .govuk-footer__list > li:nth-of-type(3) > .govuk-footer__link').should('have.attr', 'href', '/feedback');
@@ -71,18 +71,18 @@ describe(' 🇬🇧 💡 | pageLinks-UK | Terms and Conditions, Cookies ,Privacy
   // Help Section
 
   it('UK - Help - Finding commodity codes for imports or exports', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('Finding commodity codes for imports or exports');
     cy.get('div:nth-of-type(2) > .govuk-footer__list > li:nth-of-type(1) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/guidance/finding-commodity-codes-for-imports-or-exports');
   });
   it('UK - Help - Using the Trade Tariff tool to find a commodity code', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('Using the Trade Tariff tool to find a commodity code').should('not.exist');
   });
   it('UK - Help - Import and export', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('Import and export');
     cy.get('div:nth-of-type(2) > .govuk-footer__list > li:nth-of-type(2) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/topic/business-tax/import-export');
@@ -90,21 +90,21 @@ describe(' 🇬🇧 💡 | pageLinks-UK | Terms and Conditions, Cookies ,Privacy
 
   // Related information
   it('UK - Related information - UK Trade Tariff: Volume 1 – background information for importers and exporters', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('UK Trade Tariff: Volume 1 – background information for importers and exporters');
     cy.get('div:nth-of-type(3) > .govuk-footer__list > li:nth-of-type(1) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/government/collections/uk-trade-tariff-volume-1');
   });
 
   it('UK - Related information - UK Trade Tariff: Volume 3 – procedures, codes and declaration entry details', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('UK Trade Tariff: Volume 1 – background information for importers and exporters');
     cy.get('div:nth-of-type(3) > .govuk-footer__list > li:nth-of-type(2) > .govuk-footer__link').should('have.attr', 'href', 'https://www.gov.uk/government/collections/uk-trade-tariff-volume-3');
   });
 
   it('UK - Related information - API Documentation', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__list');
     cy.contains('API Documentation');
     cy.get('div:nth-of-type(3) > .govuk-footer__list > li:nth-of-type(3) > .govuk-footer__link').should('have.attr', 'href', 'https://api.trade-tariff.service.gov.uk/#gov-uk-trade-tariff-api');
@@ -112,7 +112,7 @@ describe(' 🇬🇧 💡 | pageLinks-UK | Terms and Conditions, Cookies ,Privacy
 
   // OGL link
   it('UK - Open Government Licence v3.0', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__meta.govuk-footer__row');
     cy.contains('Open Government Licence v3.0');
     cy.get('span > .govuk-footer__link').should('have.attr', 'href', 'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/');

--- a/cypress/integration/UK/FE/switchingLinks-UK.spec.js
+++ b/cypress/integration/UK/FE/switchingLinks-UK.spec.js
@@ -4,7 +4,7 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
   it('Sections / Find-commodity Page - Switching link & text available,forum links removed', function() {
     cy.visit('/sections');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // check correct text is displayed on banner as per UK - If they are at risk
     cy.contains('If you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate if your goods are not ‘at risk’ of onward movement to the EU. If they are at risk of onward movement to the EU, use the Northern Ireland Online Tariff.');
@@ -12,13 +12,13 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // click on the XI link and it should navigate to UK version
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
@@ -30,7 +30,7 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
     cy.title().should('eq', 'Declaring goods you bring into Northern Ireland \'not at risk’ of moving to the EU - GOV.UK');
     // return to UK page
     cy.go(-1);
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // other sticky links removed
     cy.get('.govuk-template')
@@ -42,53 +42,53 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
     cy.visit('/browse');
     cy.contains('Browse the tariff');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.contains('Browse the tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
 
   it('Chapters Page - switching link available,forum links removed', function() {
     cy.visit('/chapters/01');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // other sticky links removed
@@ -101,7 +101,7 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
     cy.visit('/headings/0101');
     // are we on the right page
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
 
 
@@ -109,20 +109,20 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // other sticky links removed
     cy.get('.govuk-template ')
@@ -134,57 +134,57 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
     cy.visit('/commodities/0406103010');
     // are we on the right page
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   it('Tools Page', function() {
     cy.visit('/tools');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   it('🚫 No Switching link on Quota Search Page', function() {
     cy.visit('/quota_search');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
@@ -193,127 +193,127 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
   it('Certificate Search Page', function() {
     cy.visit('/certificate_search');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   it('Additional Code Search Page', function() {
     cy.visit('/additional_code_search');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   it('Chemical Search Page', function() {
     cy.visit('/chemical_search');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   it('A-Z Page', function() {
     cy.visit('/a-z-index/a');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   // help page
   it('Help Page', function() {
     cy.visit('/help');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   // Feedback page - no switching link on feedback page
@@ -322,64 +322,64 @@ describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() 
   it('Privacy Page', function() {
     cy.visit('/privacy');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   // cookies/policy
   it('Cookies policy Page', function() {
     cy.visit('/cookies/policy');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
   // Terms and Conditions
   it('T & C  Page', function() {
     cy.visit('/terms');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the UK Integrated Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the Northern Ireland Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
   });
 });

--- a/cypress/integration/UK/FE/switchingLinks-UK.spec.js
+++ b/cypress/integration/UK/FE/switchingLinks-UK.spec.js
@@ -2,7 +2,7 @@
 describe('🇬🇧 💡 UK | switchingLinks-UK | Switching Links |', function() {
   // HOTT-96 , HOT-1051
   it('Sections / Find-commodity Page - Switching link & text available,forum links removed', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     // check header has UK information
     cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');

--- a/cypress/integration/UK/FE/titleTags-UK.spec.js
+++ b/cypress/integration/UK/FE/titleTags-UK.spec.js
@@ -1,6 +1,6 @@
 describe('🇬🇧 💡 | titleTags-UK | Validating page titles tags - meta data -UK |', function() {
   it('🧷 Landing Page - The Online Trade Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.title().should('match', /UK Integrated Online Tariff: look up commodity codes, duty and VAT rates - GOV.UK/i);
   });
   it('🧷 Browse Page - The Online Trade Tariff: Look up commodity codes, import duty, VAT and controls - GOV.UK', function() {

--- a/cypress/integration/UK/UKMobile/smokeTest-UK-M.spec.js
+++ b/cypress/integration/UK/UKMobile/smokeTest-UK-M.spec.js
@@ -6,7 +6,7 @@ describe('🚀 📱 UK 🇬🇧 💡 | smokeTest-UK-M.spec | smoke test to cover
   // Main Page
   it('🚀 UK - Main Page Validation', function() {
     cy.viewport('iphone-x');
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.mobileMenu();
     // check header has UK information
     // cy.contains('Look up commodity codes, duty and VAT rates');;
@@ -31,7 +31,7 @@ describe('🚀 📱 UK 🇬🇧 💡 | smokeTest-UK-M.spec | smoke test to cover
   // switching link works
   it('🚀 UK - Main Page - Switching link to XI available & works', function() {
     cy.viewport('iphone-x');
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
@@ -89,7 +89,7 @@ describe('🚀 📱 UK 🇬🇧 💡 | smokeTest-UK-M.spec | smoke test to cover
   // Commodity Search functionality - text search
   it('🚀 UK - Search Commodity by name ', function() {
     cy.viewport('iphone-x');
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.mobileMenu();
     // changed on 11/02/2021
     // cy.contains('Look up commodity codes, duty and VAT rates');;
@@ -100,7 +100,7 @@ describe('🚀 📱 UK 🇬🇧 💡 | smokeTest-UK-M.spec | smoke test to cover
   // Commodity Search functionality - code search
   it('🚀 UK - Search Commodity by code ', function() {
     cy.viewport('iphone-x');
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     // cy.contains('Look up commodity codes, duty and VAT rates');;
     cy.contains('Search for a commodity');
     cy.searchForCommodity('3808941000');
@@ -159,7 +159,7 @@ describe('🚀 📱 UK 🇬🇧 💡 | smokeTest-UK-M.spec | smoke test to cover
   // Date picker working and persists on UK XI sites
   it('🚀 UK - Change date and check if the data shown is same for both XI and UK', function() {
     cy.viewport('iphone-x');
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     // select Change Date and change months and years
     cy.get('.govuk-details__summary-text').click();
     cy.get('#tariff_date_day').click().clear().type(31);

--- a/cypress/integration/UK/UKMobile/smokeTest-UK-M.spec.js
+++ b/cypress/integration/UK/UKMobile/smokeTest-UK-M.spec.js
@@ -11,7 +11,7 @@ describe('🚀 📱 UK 🇬🇧 💡 | smokeTest-UK-M.spec | smoke test to cover
     // check header has UK information
     // cy.contains('Look up commodity codes, duty and VAT rates');;
     cy.title().should('matches', /UK Integrated Online Tariff: look up commodity codes, duty and VAT rates - GOV.UK/i);
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // check correct text is displayed on banner as per UK - If they are at risk
     cy.contains('If you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate if your goods are not ‘at risk’ of onward movement to the EU. If they are at risk of onward movement to the EU, use the Northern Ireland Online Tariff.');
@@ -32,20 +32,20 @@ describe('🚀 📱 UK 🇬🇧 💡 | smokeTest-UK-M.spec | smoke test to cover
   it('🚀 UK - Main Page - Switching link to XI available & works', function() {
     cy.viewport('iphone-x');
     cy.visit('/sections');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('UK Integrated Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');

--- a/cypress/integration/Welsh/welshLinks.spec.js
+++ b/cypress/integration/Welsh/welshLinks.spec.js
@@ -8,7 +8,7 @@ describe.skip('🏴󠁧󠁢󠁷󠁬󠁳󠁿 | welshLinks.spec.js | Welsh languag
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff in Welsh');
   });
   it('XI Welsh translated link', function() {
@@ -18,7 +18,7 @@ describe.skip('🏴󠁧󠁢󠁷󠁬󠁳󠁿 | welshLinks.spec.js | Welsh languag
     // switching link takes to UK welsh service
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff in Welsh');
   });
 });

--- a/cypress/integration/XI/FE/feedback-XI.spec.js
+++ b/cypress/integration/XI/FE/feedback-XI.spec.js
@@ -19,7 +19,7 @@ describe('🇪🇺 💡| feedback-XI | feedback link is available and user is ab
   });
 
   it('XI - Feedback link works - Edge cases ', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__navigation');
     cy.contains('Feedback')
         .click();
@@ -70,7 +70,7 @@ describe('🇪🇺 💡| feedback-XI | feedback link is available and user is ab
     cy.contains('Look up commodity codes, import duties, taxes and controls');
   });
   it('XI - The UK has left the EU', function() {
-    cy.visit('/sections');
+    cy.visit('/find_commodity');
     cy.get('.govuk-footer__row');
     cy.contains('The UK has left the EU');
   });

--- a/cypress/integration/XI/FE/switchingLinks-XI.spec.js
+++ b/cypress/integration/XI/FE/switchingLinks-XI.spec.js
@@ -4,7 +4,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
   it('Sections / Find-commodity Page - Switching link & text available,forum links removed', function() {
     cy.visit('/xi/sections');
     // check header has Xi information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-label').contains('Search the Northern Ireland Online Tariff');
     // check correct text is displayed on banner
@@ -12,13 +12,13 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
     // click on the UK link and it should navigate to UK version
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
@@ -29,7 +29,7 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
     cy.title().should('eq', 'Declaring goods you bring into Northern Ireland \'not at risk’ of moving to the EU - GOV.UK');
     // return to UK page
     cy.go(-1);
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // other sticky links removed
@@ -40,19 +40,19 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
   });
   it('Chapters Page - switching link available,forum links removed', function() {
     cy.visit('/xi/chapters/01');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
 
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
@@ -64,25 +64,25 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('Headings Page - switching link available,forum links removed', function() {
     cy.visit('/xi/headings/0101');
     // are we on the right page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
@@ -94,63 +94,63 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('Commodity Page', function() {
     cy.visit('/xi/commodities/0406103010');
     // are we on the right page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('Tools Page', function() {
     cy.visit('/xi/tools');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
     // Back to XI page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('🚫 No Switching link on Meursing Code finder Page', function() {
     cy.visit('xi/meursing_lookup/steps/start');
     // check header has UK information
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper')
@@ -158,176 +158,176 @@ describe('🇪🇺 💡 |switchingLinks-XI.spec|Switching Link & text ,Forum and
   });
   it('Certificate Search Page', function() {
     cy.visit('/xi/certificate_search');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
     // Back to XI page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('Additional Code Search Page', function() {
     cy.visit('/xi/additional_code_search');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
     // Back to XI page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('Chemical Search Page', function() {
     cy.visit('/xi/chemical_search');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
     // Back to XI page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('A-Z Page', function() {
     cy.visit('/xi/a-z-index/a');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
     // Back to XI page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('Help Page', function() {
     cy.visit('/xi/help');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
     // Back to XI page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
   it('Privacy Page', function() {
     cy.visit('/xi/privacy');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
     // Back to XI page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   }); it('Cookies policy Page', function() {
     cy.visit('/xi/cookies/policy');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     // UK switch link
     cy.get('.govuk-main-wrapper')
         .contains('Switch to')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
     // Back to XI page
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');
     // bottom switching link
     cy.get('.tariff-breadcrumbs.js-tariff-breadcrumbs').contains('You are viewing the Northern Ireland Online Tariff.');
     cy.get('.switch-service-control').contains('Switch to the UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
   });
 });

--- a/cypress/integration/XI/XIMobile/smokeTest-XI-M.spec.js
+++ b/cypress/integration/XI/XIMobile/smokeTest-XI-M.spec.js
@@ -30,19 +30,19 @@ describe('🚀 XI 🇪🇺 💡 | smokeTest-XI-M | Smoke test to cover basic fun
   it('🚀 XI - Main Page - Switching link to UK available & works', function() {
     cy.viewport('iphone-x');
     cy.visit('/xi/sections');
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
 
     // click on the UK link and it should navigate to UK version
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff').click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('UK Integrated Online Tariff');
     // click on the XI link and it should navigate to XI version
     cy.get('.govuk-main-wrapper');
     cy.contains('Northern Ireland Online Tariff')
         .click();
-    cy.get('.govuk-header ')
+    cy.get('.govuk-header')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
         .contains('UK Integrated Online Tariff');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -46,7 +46,7 @@ Cypress.Commands.add('mainPageUK', ()=>{
   // check header has UK information
   cy.contains('Look up commodity codes, import duties, taxes and controls'); ;
   cy.title().should('matches', /UK Integrated Online Tariff: look up commodity codes, duty and VAT rates - GOV.UK/i);
-  cy.get('.govuk-header ')
+  cy.get('.govuk-header')
       .contains('UK Integrated Online Tariff');
   // check correct text is displayed on banner as per UK - If they are at risk
   //  cy.contains('If you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate if your goods are not ‘at risk’ of onward movement to the EU. If they are at risk of onward movement to the EU, use the Northern Ireland Online Tariff.');
@@ -62,7 +62,7 @@ Cypress.Commands.add('mainPageXI', ()=>{
   // check header has UK information
   cy.contains('Look up commodity codes, import duties, taxes and controls'); ;
   cy.title().should('matches', /Northern Ireland Online Tariff: Look up commodity codes, duty and VAT rates - GOV.UK/i);
-  cy.get('.govuk-header ')
+  cy.get('.govuk-header')
       .contains('Northern Ireland Online Tariff');
   // check correct text is displayed on banner as per UK - If they are at risk
   // cy.contains('If you’re bringing goods into Northern Ireland from outside the UK and the EU, you will pay the UK duty rate if your goods are not ‘at risk’ of onward movement to the EU. If they are not at risk of onward movement to the EU, use the UK Integrated Online Tariff.');


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Altered selector input to remove extra space
- [x] Altered home path to be the current /find_commodity page

### Why?

I am doing this because:

- /sections is just a redirect to the real home path
