### PR TITLE
Fix circle ci basic auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ executors: # This is totally crazy but it's the only way to configure the enviro
       - image: 'cypress/browsers:node16.13.2-chrome97-ff96'
     environment:
       CYPRESS_BASE_URL: "https://staging.trade-tariff.service.gov.uk"
+      CYPRESS_SPACE: "STAGING"
 
 workflows:
   debug:


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds SPACE to tariff-testing circle ci nightly workflow job

### Why?

I am doing this because:

- This was missed as part of the migration over to basic auth
