### PR TITLE
CircleCI smoke tests scheduler time changed to 6am UTC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "27 8 * * *"
+          cron: "0 5 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
Smoke test scheduler - CircleCI reverted back to 6am UTC