### PR TITLE
Refactor Scheduled GHA regression runs on staging and production

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -28,7 +28,7 @@ jobs:
           quiet: true
           browser: chrome
           headless: true
-          spec: "*/**/**/*spec.js"
+          spec: "cypress/integration/HOTT-Shared/smokeTestCI.spec.js"
 
       - run: npm run posttests
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -28,7 +28,7 @@ jobs:
           quiet: true
           browser: chrome
           headless: true
-          spec: "cypress/integration/HOTT-Shared/smokeTestCI.spec.js"
+          spec: "*/**/**/*spec.js"
 
       - run: npm run posttests
 

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -51,8 +51,7 @@ jobs:
           DATE=$(date +%d-%m-%Y)
           mkdir -p docs/production/$DATE
           cp -r ../cypress/reports/mochareports/*  docs/production/$DATE/
-          cp docs/production/$DATE/report.html docs/production/$DATE/index.html
-          git add docs .
+          cp ../cypress/reports/mochareports/report.html docs/production/$DATE/index.html
 
       - name: Commit todays report to reports branch
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          mkdir -p docs/$DATE
+          mkdir -p docs/production/$DATE
           cp -r ../cypress/reports/mochareports/*  docs/production/$DATE/
           cp docs/production/$DATE/report.html docs/production/$DATE/index.html
           git add docs .

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -65,7 +65,6 @@ jobs:
         run: echo "::set-output name=date::$(date +'%d-%m-%Y')"
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
-        if: ${{ steps.cypress.outcome == 'failure' }}
         env:
           SLACK_CHANNEL: "tariffs-regression"
           SLACK_USERNAME: "Production Regression"

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -69,7 +69,6 @@ jobs:
         run: echo "::set-output name=date::$(date +'%d-%m-%Y')"
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
-        if: ${{ steps.cypress.outcome == 'failure' }}
         env:
           SLACK_CHANNEL: "tariffs-regression"
           SLACK_USERNAME: "Staging Regression"


### PR DESCRIPTION
- [ ] Removed 'if' condition on regression staging to show slack notification irrespective of pass/fail
- [ ] Removed 'if' condition on regression production to show slack notification irrespective of pass/fail
- [ ] Added folder to store production reports by date `docs/production/date`