### PR TITLE
Silence noisy schema validations

### DIFF
--- a/cypress/integration/HOTT-Shared/compareHeadingsV1V2api.spec.js
+++ b/cypress/integration/HOTT-Shared/compareHeadingsV1V2api.spec.js
@@ -17,7 +17,6 @@ context('Validating API response with previous response stored in Json file', ()
       ``;
       cy.task('validateJsonSchema', {
         data: $response.body,
-        verbose: true,
         schemaFile: data1,
       }).should('equal', null);
     });

--- a/cypress/integration/UK/API/apiValidationV1V2-UK.spec.js
+++ b/cypress/integration/UK/API/apiValidationV1V2-UK.spec.js
@@ -5,7 +5,6 @@ describe('🇬🇧 ⚙️ | apiValidationV1V2-UK | UK Basic API checks |', () =>
       expect($response.status).to.eq(200);
       cy.task('validateJsonSchema', {
         data: $response.body,
-        verbose: true,
         schemaFile: './cypress/Data/uk/v2/7202118000-2021-01-07.json',
       }).should('equal', null);
     });
@@ -39,7 +38,6 @@ describe('🇬🇧 ⚙️ | apiValidationV1V2-UK | UK Basic API checks |', () =>
       expect($response.status).to.eq(200);
       cy.task('validateJsonSchema', {
         data: $response.body,
-        verbose: true,
         schemaFile: './cypress/Data/uk/v1/7202118000-2021-01-07.json',
       }).should('equal', null);
     });

--- a/cypress/integration/UK/API/commcodesAPIvalidation-UK.spec.js
+++ b/cypress/integration/UK/API/commcodesAPIvalidation-UK.spec.js
@@ -29,7 +29,6 @@ context('🇬🇧 ⚙️ | commcodesAPIvalidation-UK |Validate API response for 
 
         cy.task('validateJsonSchema', {
           data: $response.body,
-          verbose: true,
           schemaFile: `cypress/Data/uk/v2/${commodity_ids[i]}-${fixture_timestamp}.json`,
 
         })
@@ -68,7 +67,6 @@ context('🇬🇧 ⚙️ | commcodesAPIvalidation-UK |Validate API response for 
 
         cy.task('validateJsonSchema', {
           data: $response.body,
-          verbose: true,
           schemaFile: `cypress/Data/uk/v1/${commodity_ids[i]}-${fixture_timestamp}.json`,
 
         })

--- a/cypress/integration/UK/API/swaggerValidation.spec.js
+++ b/cypress/integration/UK/API/swaggerValidation.spec.js
@@ -14,7 +14,6 @@ describe.skip('| swaggerValidation | Basic API checks |', () => {
         method: 'get',
         statusCode: 200,
         responseSchema: $response.body,
-        verbose: true, // optional, default: false
       });
     });
   });

--- a/cypress/integration/XI/API/apiValidationV1V2-XI.spec.js
+++ b/cypress/integration/XI/API/apiValidationV1V2-XI.spec.js
@@ -6,7 +6,6 @@ describe('🇪🇺 ⚙️ | apiValidationV1V2-XI | XI Basic API checks |', () =>
 
       cy.task('validateJsonSchema', {
         data: $response.body,
-        verbose: true,
         schemaFile: './cypress/Data/uk/v2/7202118000-2021-01-07.json',
       }).should('equal', null);
     });
@@ -43,7 +42,6 @@ describe('🇪🇺 ⚙️ | apiValidationV1V2-XI | XI Basic API checks |', () =>
 
       cy.task('validateJsonSchema', {
         data: $response.body,
-        verbose: true,
         schemaFile: './cypress/Data/uk/v1/7202118000-2021-01-07.json',
       }).should('equal', null);
     });

--- a/cypress/integration/XI/API/commcodesAPIvalidation-XI.spec.js
+++ b/cypress/integration/XI/API/commcodesAPIvalidation-XI.spec.js
@@ -29,7 +29,6 @@ context('🇪🇺 ⚙️ | commcodesAPIvalidation-XI | Validate API response for
         expect($response.status).to.eq(200);
         cy.task('validateJsonSchema', {
           data: $response.body,
-          verbose: true,
           schemaFile: `cypress/Data/uk/v2/${commodity_ids[i]}-${fixture_timestamp}.json`,
 
         })
@@ -65,7 +64,6 @@ context('🇪🇺 ⚙️ | commcodesAPIvalidation-XI | Validate API response for
 
         cy.task('validateJsonSchema', {
           data: $response.body,
-          verbose: true,
           schemaFile: `cypress/Data/uk/v1/${commodity_ids[i]}-${fixture_timestamp}.json`,
 
         })

--- a/cypress/integration/XI/API/countriesApi-XI.spec.js
+++ b/cypress/integration/XI/API/countriesApi-XI.spec.js
@@ -10,7 +10,6 @@ describe.skip('🇪🇺 | countriesApi-XI | XI Country Selection |', function() 
 
         cy.task('validateJsonSchema', {
           data: $response.body,
-          verbose: true,
           schemaFile: './cypress/Data/xi/countriesXI.json',
         }).should('equal', null);
       });


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Removes verbose output from schema validations

### Why?

I am doing this because:

- This currently adds 1ks of lines of output in the regression suite stdout that gets truncated
