### PR TITLE
HOTT 1770 Display Cypress failed test screenshots in Circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
             CYPRESS_BASE_URL: "https://staging.trade-tariff.service.gov.uk"
             CYPRESS_SPACE: "STAGING"
           command: bin/all-smoke-tests.sh
+      - store_artifacts:
+          path: cypress/screenshots
 
 workflows:
   debug:

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -51,7 +51,7 @@ module.exports = defineConfig({
     'chromeWebSecurity': false,
     'firefoxWebSecurity': false,
     'video': false,
-    'screenshotOnRunFailure': false,
+    'screenshotOnRunFailure': true,
     'projectId': '7p655m',
     'parseSpecialCharSequences': false,
     'defaultCommandTimeout': 15000,


### PR DESCRIPTION
### Jira link

[HOTT-1770](https://transformuk.atlassian.net/browse/HOTT-1770)

### What?

I have added/removed/altered:

- [ ] updated CircleCI config.yml to display failed test screenshot on CircleCI artefacts tab

### Why?

I am doing this because:

- It will make it easier to find the cause of failing tests