### PR TITLE
Upgraded cypress tags

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,9 +2454,9 @@ cypress-mochawesome-reporter@^3.2.2:
     mochawesome-report-generator "^6.2.0"
 
 cypress-tags@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cypress-tags/-/cypress-tags-1.1.1.tgz#b74511b428d14397d4134563b9625bae289c12d5"
-  integrity sha512-ejYe9NzLcgXHAzYx7GhkJLjunmpi/STHTNIgKcLo/thvSKBJVmXMv1zgOtYrGyYrS8oBSveqT004iTphSzF2/w==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cypress-tags/-/cypress-tags-1.1.2.tgz#f0aeb29685b0906bba2eca69e7349943cbbd1eba"
+  integrity sha512-5aCGrhmDRQuXfRHJRFy66gBmMvBpsY1+ez5JD/cyjCYjvOVlJ7ED+kovUEdi+9pyDsbFJkQl0HjS6N3ERyb7Ig==
   dependencies:
     "@cypress/browserify-preprocessor" "^3.0.1"
     boolean-parser "0.0.2"
@@ -2752,9 +2752,9 @@ ecc-jsbn@~0.1.1:
     safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.4.251:
-  version "1.4.256"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.256.tgz#c735032f412505e8e0482f147a8ff10cfca45bf4"
-  integrity sha512-x+JnqyluoJv8I0U9gVe+Sk2st8vF0CzMt78SXxuoWCooLLY2k5VerIBdpvG7ql6GKI4dzNnPjmqgDJ76EdaAKw==
+  version "1.4.257"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.257.tgz#895dc73c6bb58d1235dc80879ecbca0bcba96e2c"
+  integrity sha512-C65sIwHqNnPC2ADMfse/jWTtmhZMII+x6ADI9gENzrOiI7BpxmfKFE84WkIEl5wEg+7+SfIkwChDlsd1Erju2A==
 
 elliptic@^6.5.3:
   version "6.5.4"


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Upgraded cypress-tags

### Why?

I am doing this because:

- The version we were using was yanked which broke our nightly runs. Looking through their commit history since v1.0.2 nothing immediately stands our as unusual - just looks like an unhelpful response to a borked ownership change.

