### PR TITLE
Fixes reference in regression development workflow

### DIFF
--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -66,7 +66,7 @@ jobs:
           SLACK_ICON_EMOJI: ":alphabet-yellow-s:"
           SLACK_COLOR: ${{ job.status }}
           SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
-          SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/devonly/${{ steps.date.outputs.date }}/
+          SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/development/${{ steps.date.outputs.date }}/
 
       - name: Push changes
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Fixed the broken reference in the regressionDevelopment workflow

### Why?

I am doing this because:

- We need to match the directory where the reports are written in order for the slack link to work with github pages
