### PR TITLE
HOTT-2089: Optimise storage-expensive reports

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -39,7 +39,12 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
+          rm -rf ../cypress/reports/mochawesome/screenshots
+          rm -rf ../cypress/reports/mochawesome/assets
           cp -a ../cypress/reports/mochawesome  docs/production/$DATE
+          pushd docs/production/$DATE
+          ln -s ../../assets/
+          popd
           git add docs .
       - name: Commit todays report to reports branch
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -39,10 +39,10 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          rm -rf ../cypress/reports/mochawesome/screenshots
-          rm -rf ../cypress/reports/mochawesome/assets
           cp -a ../cypress/reports/mochawesome  docs/production/$DATE
           pushd docs/production/$DATE
+          rm -rf assets
+          rm -rf screenshots
           ln -s ../../assets/
           popd
           git add docs .

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
+          [ -e docs/production/$DATE ] && rm -rf docs/production/$DATE
           cp -a ../cypress/reports/mochawesome  docs/production/$DATE
           pushd docs/production/$DATE
           rm -rf assets

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -45,8 +45,9 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          cp -a ../cypress/reports/mochawesome  docs/production/$DATE
-          pushd docs/production/$DATE
+          [ -e docs/development/$DATE ] && rm -rf docs/development/$DATE
+          cp -a ../cypress/reports/mochawesome  docs/development/$DATE
+          pushd docs/development/$DATE
           rm -rf assets
           rm -rf screenshots
           ln -s ../../assets/

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -45,7 +45,12 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          cp -a ../cypress/reports/mochawesome  docs/development/$DATE
+          rm -rf ../cypress/reports/mochawesome/screenshots
+          rm -rf ../cypress/reports/mochawesome/assets
+          cp -a ../cypress/reports/mochawesome  docs/production/$DATE
+          pushd docs/production/$DATE
+          ln -s ../../assets/
+          popd
           git add docs .
       - name: Commit todays report to reports branch
         run: |

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -45,10 +45,10 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          rm -rf ../cypress/reports/mochawesome/screenshots
-          rm -rf ../cypress/reports/mochawesome/assets
           cp -a ../cypress/reports/mochawesome  docs/production/$DATE
           pushd docs/production/$DATE
+          rm -rf assets
+          rm -rf screenshots
           ln -s ../../assets/
           popd
           git add docs .

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -45,10 +45,10 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          rm -rf ../cypress/reports/mochawesome/screenshots
-          rm -rf ../cypress/reports/mochawesome/assets
           cp -a ../cypress/reports/mochawesome  docs/production/$DATE
           pushd docs/production/$DATE
+          rm -rf assets
+          rm -rf screenshots
           ln -s ../../assets/
           popd
           git add docs .

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -45,7 +45,12 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          cp -a ../cypress/reports/mochawesome  docs/staging/$DATE
+          rm -rf ../cypress/reports/mochawesome/screenshots
+          rm -rf ../cypress/reports/mochawesome/assets
+          cp -a ../cypress/reports/mochawesome  docs/production/$DATE
+          pushd docs/production/$DATE
+          ln -s ../../assets/
+          popd
           git add docs .
       - name: Commit todays report to reports branch
         run: |

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -45,8 +45,9 @@ jobs:
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
-          cp -a ../cypress/reports/mochawesome  docs/production/$DATE
-          pushd docs/production/$DATE
+          [ -e docs/staging/$DATE ] && rm -rf docs/staging/$DATE
+          cp -a ../cypress/reports/mochawesome  docs/staging/$DATE
+          pushd docs/staging/$DATE
           rm -rf assets
           rm -rf screenshots
           ln -s ../../assets/


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2089

### What?

I have added/removed/altered:

- [x] Use symbolic links for assets in development, staging and production reports
- [x] Remove dead/inaccessible screenshots

### Why?

I am doing this because:

- It takes me about a minute to checkout this repo just to download some assets of days previous reports

### AC

- [ ] Generated reports and pages still work correctly