### PR TITLE
Fixes circle ci integration status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Github Actions Regression Production](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regression.yml/badge.svg?branch=main&event=schedule)](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regression.yml)
 [![Github Actions Regression Staging](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionStaging.yml/badge.svg?branch=main&event=schedule)](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionStaging.yml)
 [![Github Actions Regression Development](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionDevelopment.yml/badge.svg?branch=main&event=schedule)](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionStaging.yml)
-[![CircleCI Smoke Tests](https://circleci.com/gh/circleci/circleci-docs.svg?style=svg)](https://circleci.com/gh/circleci/circleci-docs)
+[![CircleCI Smoke Tests](https://circleci.com/gh/trade-tariff/trade-tariff-testing.svg?style=svg)](https://circleci.com/gh/trade-tariff/trade-tariff-testing.svg?style=svg)
 
 This repository is responsible for validating integrations between different applications in the Online Trade Tariff service
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8156884/195356434-1f481d22-7e78-42e4-adeb-42eb59fe2a51.png)

### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Fixes broken circle ci integration test status badge

### Why?

I am doing this because:

- When we look at the home page of the tests we should ideally see indicators of everything being green
