### PR TITLE
add new tests for tolerances and cumulation links

### DIFF
--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/601-RoO-e2e-NWO-GSP-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/601-RoO-e2e-NWO-GSP-InsuffPro.cy.js
@@ -25,6 +25,8 @@ describe('| 601-RoO-e2e-NWO-GSP-InsuffProcess.spec | NWO + GSP Scheme + insuffic
     // Min Processing Yes
     cy.go(-2);
     cy.minimalOps('Generalised Scheme of Preferences (GSP)', 'yes');
+    // Product subDivisions
+    cy.subDivision('5808100000', 'Special woven fabrics; tufted textile fabrics; lace; tapestries; trimmings; embroidery');
     // product specific rules?
     cy.prodSpecRules('Your goods do not meet any of these rules.');
     // Origin requirements met

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/604-RoO-e2e-NWO-OneSchm-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/604-RoO-e2e-NWO-OneSchm-InsuffPro.cy.js
@@ -45,4 +45,32 @@ describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient
     // Origin requirements met
     cy.rooNotMetEx('Exporting', 'the UK', '5808100000', 'UK-Japan Comprehensive Economic Partnership Agreement', 'Japan');
   });
+  it('Importing - NWO + One Scheme + Insufficient processing + tolerances and cumulation page - Japan', function() {
+    cy.visit('/commodities/5808100000?country=JP#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Japan', 'import');
+    // How Originating is defined
+    cy.howOrginating('Japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-Japan Comprehensive Economic Partnership Agreement');
+    // what components
+    cy.whatComponents('UK-Japan Comprehensive Economic Partnership Agreement');
+    // Wholly Obtained ?
+    cy.whollyObtained('Japan', 'no');
+    // Your goods are not wholly obtained
+    cy.notWhollyObtained('Japan');
+    // cumulation
+    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'no');
+    // Origin requirements not met
+    cy.rooNotMetImp('Importing', 'Japan', '5808100000', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.go(-1);
+    // Verify tolerances page
+    cy.tolerance('Importing', '5808100000', 'Japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // Verify cumulation page
+    cy.clkCumulationLnk();
+    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+  });
 });

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/605-RoO-e2e-NWO-OneSchm-SuffPro-subdiv.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/605-RoO-e2e-NWO-OneSchm-SuffPro-subdiv.cy.js
@@ -25,7 +25,8 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro-subdiv.spec | NWO + One Scheme + Suffici
     // subdivision
     cy.subDivision('5208121620', 'Woven fabrics of cotton');
     // product specific rules?
-    cy.prodSpecRules('Manufacture from yarn ; or Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling) where the value of the unprinted fabric used does not exceed 47.5% of the ex-works price of the product.');
+    cy.prodSpecRules('Manufacture from yarn');
+    // cy.prodSpecRules('Manufacture from yarn ; or Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling) where the value of the unprinted fabric used does not exceed 47.5% of the ex-works price of the product.');
     // Origin requirements met
     cy.rooReqMet('Importing', 'Botswana', '5208121620', 'SACUM-UK Economic Partnership Agreement (EPA)');
     // Validate if product specific rules are not met
@@ -57,7 +58,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro-subdiv.spec | NWO + One Scheme + Suffici
     // subdivision
     cy.subDivision('5208121620', 'Woven fabrics of cotton');
     // product specific rules?
-    cy.prodSpecRules('Manufacture from yarn ; or Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling) where the value of the unprinted fabric used does not exceed 47.5% of the ex-works price of the product.');
+    cy.prodSpecRules('Printing accompanied by at least two preparatory or finishing operations (such as scouring, bleaching, mercerising, heat setting, raising, calendering, shrink resistance processing, permanent finishing, decatising, impregnating, mending and burling) where the value of the unprinted fabric used does not exceed 47.5% of the ex-works price of the product.');
     // Origin requirements met
     cy.rooReqMetEx('Exporting', 'the UK', '5208121620', 'SACUM-UK Economic Partnership Agreement (EPA)');
     // Validate if product specific rules are not met

--- a/cypress/support/rooCommands.js
+++ b/cypress/support/rooCommands.js
@@ -195,6 +195,28 @@ Cypress.Commands.add('rooNotMet', (tradetype, country, code, scheme)=>{
   cy.contains(`Are you importing goods into the UK or into ${country}?`);
 });
 
+// Tolerance page verification
+Cypress.Commands.add('tolerance', (tradetype, code, country, scheme) => {
+  cy.contains('Tolerances');
+  cy.contains('Tolerance rules allow you to use a limited quantity of non-originating materials that are normally prohibited by the product specific rule.');
+  cy.get('#tolerances-section > p:nth-child(3) > a').contains('Find out more about tolerances').click();
+  cy.contains('Are your goods originating?');
+  cy.contains('Tolerances');
+  cy.contains('‘Tolerances’ represent a provision for the relaxation of the rules of origin under certain conditions.');
+  cy.contains(`Tolerances in the ${scheme}`);
+  cy.go(-1);
+  cy.contains(`${tradetype} commodity ${code} from ${country}`);
+  cy.contains('Rules of Origin not met');
+  cy.contains(`Your product does not appear to meet the rules of origin requirements for the ${scheme}.`);
+});
+
+// Click cumulation link on Rules of Origin Not Met
+Cypress.Commands.add('clkCumulationLnk', () => {
+  cy.contains('Cumulation rules');
+  cy.contains('Check what cumulation rules apply to the movement of goods under the UK-Japan Comprehensive Economic Partnership Agreement.');
+  cy.get('#cumulation-section > p:nth-child(3) > a').click();
+});
+
 // Origin not met - Import
 Cypress.Commands.add('rooNotMetImp', (tradetype, country, code, scheme)=>{
   cy.contains(`${tradetype} commodity ${code} from ${country}`);


### PR DESCRIPTION
### Jira link

[HOTT-1714](https://transformuk.atlassian.net/browse/HOTT-1714)

### What?

I have added/removed/altered the following:

- Added new regression tests to verify tolerances and accumulation links and pages on rules of origin not met screen

### Why?

I am doing this because:

- It would be good to have new regression tests for new screens introduced as part of RoO scenarios for different user journeys.

ACs:

- Verified all acceptance criteria as part of HOTT-1714 ticket testing.