### PR TITLE
HOTT-2139: Adds e2e spec for intercept message functionality

### DIFF
--- a/cypress/e2e/BetaSearch/betaSearch.cy.js
+++ b/cypress/e2e/BetaSearch/betaSearch.cy.js
@@ -68,4 +68,11 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.get('.facet-classifications-tag').should('not.exist');
     cy.url().should('not.include', '6211');
   });
+
+  it('Searching for `access equipment` returns an intercept message', function() {
+    cy.visit('/find_commodity');
+    cy.searchForCommodity('access equipment');
+    cy.get('#intercept-message > a').eq(1).click();
+    cy.url().should('include', '/chapters/85');
+  });
 });


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2139

### What?

I have added/removed/altered:

- [x] Added an integration test of the intercept message functionality

### Why?

I am doing this because:

- We've recently added intercept message functionality to the frontend and have tweaked the link generation in backend see https://github.com/trade-tariff/trade-tariff-frontend/pull/1103 and https://github.com/trade-tariff/trade-tariff-backend/pull/827
