### PR TITLE
HOTT-2048: Adds e2e for preference codes

### DIFF
--- a/cypress/e2e/measureTypePreferenceCodes.cy.js
+++ b/cypress/e2e/measureTypePreferenceCodes.cy.js
@@ -1,0 +1,19 @@
+describe('measure type preference codes', function() {
+  it('should generate a link that is navigable', function() {
+    cy.visit('/commodities/1516209821');
+
+    cy.get('#measure-20001695 > td > span > a')
+        .contains('Third country duty')
+        .should(
+            'have.attr',
+            'href',
+            '/measure_types/103/preference_codes/100?geographical_area_id=1011',
+        )
+        .click();
+
+    cy.url().should(
+        'include',
+        '/measure_types/103/preference_codes/100?geographical_area_id=1011',
+    );
+  });
+});


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2048

### What?

I have added/removed/altered:

- [x] Add an integration check to validate the generation of preference codes and their rendering on the frontend

### Why?

I am doing this because:

- This is required to validate the integration between https://github.com/trade-tariff/trade-tariff-frontend/pull/1109 and https://github.com/trade-tariff/trade-tariff-backend/pull/831
