### PR TITLE
HOTT-2162: Adds beta search spec for spelling correction

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -19,7 +19,7 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.get('.image-guide').should('not.exist');
   });
 
-  it('Search result corrects spelling for `halbiut` and supports uncorrecting the spelling', function() {
+  it('Search result corrects spelling for `halbiut` and supports using the original search query', function() {
     cy.visit('/find_commodity');
     cy.searchForCommodity('halbiut');
 

--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -19,11 +19,20 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.get('.image-guide').should('not.exist');
   });
 
-  it('Search result corrects spelling for `halbiut`', function() {
+  it('Search result corrects spelling for `halbiut` and supports uncorrecting the spelling', function() {
     cy.visit('/find_commodity');
     cy.searchForCommodity('halbiut');
 
     cy.get('h1').contains('Search results for ‘halibut’');
+    cy.get('div#search-results-spelling > p.corrected-search-results > span.non-corrected-search-results > a')
+        .click();
+
+    cy.url().should(
+        'include',
+        '/search?q=halbiut&spell=0',
+    );
+
+    cy.get('#intercept-message').contains('There are no results');
   });
 
   it('Search result returns results for synonyms', function() {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2169

### What?

I have added/removed/altered:

- [x] Added spec to validate plumbing together of spelling correction feature

### Why?

See https://github.com/trade-tariff/trade-tariff-frontend/pull/1112,
https://github.com/trade-tariff/trade-tariff-backend/pull/835 and https://github.com/trade-tariff/trade-tariff-search-query-parser/pull/73

I am doing this because:

- This is required to validate the plumbing between the frontend -> backend -> search query parser
