### PR TITLE
HOTT-2178: Add support for import/export guidance checks

### DIFF
--- a/cypress/e2e/measureConditionGuidance.cy.js
+++ b/cypress/e2e/measureConditionGuidance.cy.js
@@ -2,16 +2,16 @@ describe('Measure condition popup CHIEF/CDS guidance', function() {
   context('when on the UK service', function() {
     it('shows guidance', function() {
       cy.visit('/commodities/6403990510#import');
-      cy.get('#measure-20174652').contains('Conditions').click().wait(200);
-      cy.commodityGuidance();
+      cy.commodityImportGuidance();
+      cy.commodityExportGuidance();
     });
   });
 
   context('when on the XI service', function() {
     it('shows guidance', function() {
       cy.visit('/xi/commodities/6403990510#import');
-      cy.get('#measure-20174652').contains('Conditions').click().wait(200);
-      cy.commodityGuidance();
+      cy.commodityImportGuidance();
+      cy.commodityExportGuidance();
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -235,19 +235,14 @@ Cypress.Commands.add('code999L', ()=>{
   cy.get('.info-content').contains('This waiver cannot be used for goods that are imported/exported or moved to/from Northern Ireland.');
 });
 
-Cypress.Commands.add('certificateGuidance', ()=>{
-  cy.contains('Using this certificate on CDS or CHIEF').click();
-  cy.contains('CDS guidance:');
-  cy.contains('CHIEF guidance:');
-  cy.contains('Commodity codes that require this certificate').click();
+Cypress.Commands.add('commodityImportGuidance', ()=>{
+  cy.get('#import-measure-references').should('contain', 'CDS guidance');
+  cy.get('#import-measure-references').should('not.contain', 'CHIEF guidance');
 });
 
-Cypress.Commands.add('commodityGuidance', ()=>{
-  cy.get('.info-inner').contains('Guidance for completing Box 44 or Data Element 2/3').click();
-  cy.contains('CDS guidance');
-  cy.contains('CHIEF guidance');
-  cy.get('.info-inner').contains('document status codes: ');
-  cy.get('.info-inner').contains(' status codes');
+Cypress.Commands.add('commodityExportGuidance', ()=>{
+  cy.get('#export-measure-references').should('contain', 'CDS guidance');
+  cy.get('#export-measure-references').should('contain', 'CHIEF guidance');
 });
 // Validate API Document page
 Cypress.Commands.add('apiDocPage', ()=>{


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2178

### What?

I have added/removed/altered:

- [x] Adds more specific coverage of import/export tab behaviour
- [x] Removes an unused command
- [x] Renames test file to reflect we're checking both services
- [x] Adds extra command to validate import/export modal references

### Why?

I am doing this because:

- This is required to validate the changes here https://github.com/trade-tariff/trade-tariff-frontend/pull/1132
- We weren't using the guidance command
