### PR TITLE
HOTT-2188: Adds e2e tests for validity periods

### DIFF
--- a/cypress/e2e/validityPeriods.cy.js
+++ b/cypress/e2e/validityPeriods.cy.js
@@ -1,0 +1,28 @@
+describe('Goods nomenclature history', function() {
+  context('when fetching expired headings', function() {
+    const path = '/headings/6908';
+
+    it('renders a valid periods view of the heading', function() {
+      cy.visit(path, {'failOnStatusCode': false});
+      cy.contains('The heading you entered could not be found for the date selected');
+    });
+  });
+
+  context('when fetching expired subheadings', function() {
+    const path = '/subheadings/0102900500-80';
+
+    it('renders a valid periods view of the subheading', function() {
+      cy.visit(path, {'failOnStatusCode': false});
+      cy.contains('The subheading you entered could not be found for the date selected');
+    });
+  });
+
+  context('when fetching expired commodities', function() {
+    const path = '/commodities/6908100000';
+
+    it('renders a valid periods view of the commodity', function() {
+      cy.visit(path, {'failOnStatusCode': false});
+      cy.contains('The commodity code you entered could not be found for the date selected');
+    });
+  });
+});


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2188

### What?

I have added/removed/altered:

- [x] Added e2e test of heading validity periods integration
- [x] Added e2e test of subheading validity periods integration
- [x] Added e2e test of commodity validity periods integration

### Why?

I am doing this because:

- This is required to verify an important feature when browsing goods nomenclature and would have caught an issue not spotted by unit tests
