### PR TITLE
adding new tests for non-alteration and direct transport links

### DIFF
--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/601-RoO-e2e-NWO-GSP-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/601-RoO-e2e-NWO-GSP-InsuffPro.cy.js
@@ -17,7 +17,7 @@ describe('| 601-RoO-e2e-NWO-GSP-InsuffProcess.spec | NWO + GSP Scheme + insuffic
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Bangladesh');
     // cumulation
-    cy.cumulation('gsp', 'Generalised Scheme of Preferences (GSP)');
+    cy.cumulation('gsp', '5808100000', 'BD', 'Generalised Scheme of Preferences (GSP)');
     // Min Processing NO
     cy.minimalOps('Generalised Scheme of Preferences (GSP)', 'no');
     // Origin requirements met

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.cy.js
@@ -28,7 +28,7 @@ describe('| 602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.spec | NWO + Multi-NonGSP
       // Your goods are not wholly obtained
       cy.notWhollyObtained(`${trade_selection[i]}`);
       // cumulation
-      cy.cumulation('vietnam', 'UK-Vietnam Free Trade Agreement');
+      cy.cumulation('vietnam', '6004100091', 'VN', 'UK-Vietnam Free Trade Agreement');
       // min Operations met ?
       cy.minimalOps('UK-Vietnam Free Trade Agreement', 'no');
       // Origin requirements NOT met

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.cy.js
@@ -3,11 +3,11 @@
 /* eslint-disable max-len */
 // NWO + Multi-NonGSP + Insufficient processing = RoO Not met
 //
-describe.skip('| 602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.spec | NWO + Multi-NonGSP + Insufficient processing |', function() {
+describe('| 602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.spec | NWO + Multi-NonGSP + Insufficient processing |', function() {
   const trade_type = ['import', 'export'];
   const trade_country = ['Vietnam', 'United Kingdom'];
   const trade_country2 = ['Vietnam', 'the UK'];
-  const trade_selection = ['Vietnam', 'UK'];
+  const trade_selection = ['Vietnam', 'the UK'];
   for ( let i=0; i<trade_type.length; i++) {
     it(`${trade_type[i]} - NWO + Multi-NonGSP + Insufficient processing  + Vietnam`, function() {
       cy.visit('/commodities/6004100091?country=VN#rules-of-origin');
@@ -32,7 +32,8 @@ describe.skip('| 602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.spec | NWO + Multi-N
       // min Operations met ?
       cy.minimalOps('UK-Vietnam Free Trade Agreement', 'no');
       // Origin requirements NOT met
-      cy.rooNotMetMulti('Vietnam', '6004100091', 'UK-Vietnam Free Trade Agreement');
+      const trade_type_str = `${trade_type[i]}`[0].toUpperCase() + `${trade_type[i]}`.slice(1) + 'ing';
+      cy.rooNotMetMulti(`${trade_type_str}`, 'Vietnam', '6004100091', 'UK-Vietnam Free Trade Agreement');
     });
   }
 });

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/603-RoO-e2e-NWO-MultiSchm-NonGSP-SuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/603-RoO-e2e-NWO-MultiSchm-NonGSP-SuffPro.cy.js
@@ -21,7 +21,7 @@ describe('| RoO-e2e-NWO-MultiSchm-NonGSP-SuffPro.spec | NWO + Multi-NonGSP + Suf
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Vietnam');
     // cumulation
-    cy.cumulation('vietnam', 'UK-Vietnam Free Trade Agreement');
+    cy.cumulation('vietnam', '6004100091', 'VN', 'UK-Vietnam Free Trade Agreement');
     // min Operations met ?
     cy.minimalOps('UK-Vietnam Free Trade Agreement', 'yes');
     // sub Division

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/604-RoO-e2e-NWO-OneSchm-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/604-RoO-e2e-NWO-OneSchm-InsuffPro.cy.js
@@ -73,4 +73,52 @@ describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient
     cy.clkCumulationLnk();
     cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
   });
+  it('Importing - NWO + One Scheme + Insufficient processing + without cumulation block - Japan', function() {
+    cy.visit('/commodities/0101291000?country=JP#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Japan', 'import');
+    // How Originating is defined
+    cy.howOrginating('Japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-Japan Comprehensive Economic Partnership Agreement');
+    // what components
+    cy.whatComponents('UK-Japan Comprehensive Economic Partnership Agreement');
+    // Wholly Obtained ?
+    cy.whollyObtained('Japan', 'no');
+    // Origin requirements not met
+    cy.rooNotMetImp('Importing', 'Japan', '0101291000', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.go(-1);
+    // Verify tolerances page
+    cy.tolerance('Importing', '0101291000', 'Japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // Without cumulation block
+    cy.should('not.contains.text', 'Cumulation rules');
+  });
+  it('Importing - NWO + One Scheme + Insufficient processing + with cumulation block - Japan', function() {
+    cy.visit('/commodities/1602321110?country=JP#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Japan', 'import');
+    // How Originating is defined
+    cy.howOrginating('Japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-Japan Comprehensive Economic Partnership Agreement');
+    // what components
+    cy.whatComponents('UK-Japan Comprehensive Economic Partnership Agreement');
+    // Wholly Obtained ?
+    cy.whollyObtained('Japan', 'no');
+    // Your goods are not wholly obtained
+    cy.notWhollyObtained('Japan');
+    // cumulation
+    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'no');
+    // Origin requirements not met
+    cy.rooNotMetImp('Importing', 'Japan', '1602321110', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.go(-1);
+    // with cumulation block
+    cy.clkCumulationLnk();
+    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+  });
 });

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/604-RoO-e2e-NWO-OneSchm-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/604-RoO-e2e-NWO-OneSchm-InsuffPro.cy.js
@@ -18,7 +18,7 @@ describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Japan');
     // cumulation
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '5808100000', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'no');
     // Origin requirements met
     cy.rooNotMet('Importing', 'Japan', '5808100000', 'UK-Japan Comprehensive Economic Partnership Agreement');
@@ -40,7 +40,7 @@ describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient
     // Your goods are not wholly obtained
     cy.notWhollyObtained('the UK');
     // cumulation
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '5808100000', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'no');
     // Origin requirements met
     cy.rooNotMetEx('Exporting', 'the UK', '5808100000', 'UK-Japan Comprehensive Economic Partnership Agreement', 'Japan');
@@ -62,7 +62,7 @@ describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Japan');
     // cumulation
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '5808100000', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'no');
     // Origin requirements not met
     cy.rooNotMetImp('Importing', 'Japan', '5808100000', 'UK-Japan Comprehensive Economic Partnership Agreement');
@@ -71,7 +71,7 @@ describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient
     cy.tolerance('Importing', '5808100000', 'Japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
     // Verify cumulation page
     cy.clkCumulationLnk();
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '5808100000', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
   });
   it('Importing - NWO + One Scheme + Insufficient processing + without cumulation block - Japan', function() {
     cy.visit('/commodities/0101291000?country=JP#rules-of-origin');
@@ -112,13 +112,13 @@ describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Japan');
     // cumulation
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '1602321110', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'no');
     // Origin requirements not met
     cy.rooNotMetImp('Importing', 'Japan', '1602321110', 'UK-Japan Comprehensive Economic Partnership Agreement');
     cy.go(-1);
     // with cumulation block
     cy.clkCumulationLnk();
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '1602321110', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
   });
 });

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/605-RoO-e2e-NWO-OneSchm-SuffPro-subdiv.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/605-RoO-e2e-NWO-OneSchm-SuffPro-subdiv.cy.js
@@ -19,7 +19,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro-subdiv.spec | NWO + One Scheme + Suffici
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Botswana');
     // cumulation
-    cy.cumulation('sacum', 'SACUM-UK Economic Partnership Agreement (EPA)');
+    cy.cumulation('sacum', '5208121620', 'BW', 'SACUM-UK Economic Partnership Agreement (EPA)');
     // min Operations met ?
     cy.minimalOps('SACUM-UK Economic Partnership Agreement (EPA)', 'yes');
     // subdivision
@@ -52,7 +52,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro-subdiv.spec | NWO + One Scheme + Suffici
     // Your goods are not wholly obtained
     cy.notWhollyObtained('the UK');
     // cumulation
-    cy.cumulation('sacum', 'SACUM-UK Economic Partnership Agreement (EPA)');
+    cy.cumulation('sacum', '5208121620', 'BW', 'SACUM-UK Economic Partnership Agreement (EPA)');
     // min Operations met ?
     cy.minimalOps('SACUM-UK Economic Partnership Agreement (EPA)', 'yes');
     // subdivision

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/606-RoO-e2e-NWO-OneSchm-SuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/606-RoO-e2e-NWO-OneSchm-SuffPro.cy.js
@@ -19,7 +19,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient pro
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Japan');
     // cumulation
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '6004100091', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     // min Operations met ?
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'yes');
     // product specific rules?
@@ -49,7 +49,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient pro
     // Your goods are not wholly obtained
     cy.notWhollyObtained('the UK');
     // cumulation
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '6004100091', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     // min Operations met ?
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'yes');
     // product specific rules?
@@ -79,7 +79,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient pro
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Egypt');
     // cumulation
-    cy.cumulation('egypt', 'UK-Egypt Association Agreement');
+    cy.cumulation('egypt', '1301200000', 'EG', 'UK-Egypt Association Agreement');
     // min Operations met ?
     cy.minimalOps('UK-Egypt Association Agreement', 'yes');
     // Provide more information about your product
@@ -111,7 +111,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient pro
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Egypt');
     // cumulation
-    cy.cumulation('egypt', 'UK-Egypt Association Agreement');
+    cy.cumulation('egypt', '0502100000', 'EG', 'UK-Egypt Association Agreement');
     // min Operations met ?
     cy.minimalOps('UK-Egypt Association Agreement', 'yes');
     // Provide more information about your product

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/703-RoO-e2e-WO-Multi-nonGSP.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/703-RoO-e2e-WO-Multi-nonGSP.cy.js
@@ -19,7 +19,7 @@ describe('| RoO-e2e-WO-Multiple-nonGSP.spec | WO + Multiple Schemes + nonGSP - V
     // Origin requirements met
     cy.originMet('Vietnam', '0201100021', 'UK-Vietnam Free Trade Agreement');
   });
-  it.skip('Export - WO + Multiple Schemes + GSP - Vietnam', function() {
+  it('Export - WO + Multiple Schemes + GSP - Vietnam', function() {
     cy.visit('/commodities/0201100021?country=VN#rules-of-origin');
     // click Check Rules of Origin button
     cy.checkRoO();
@@ -34,8 +34,19 @@ describe('| RoO-e2e-WO-Multiple-nonGSP.spec | WO + Multiple Schemes + nonGSP - V
     // what components
     cy.whatComponents('UK-Vietnam Free Trade Agreement');
     // Wholly Obtained ?
-    cy.whollyObtained('Vietnam', 'yes');
+    cy.whollyObtained('the UK', 'yes');
     // Origin requirements met
-    cy.originMet('Vietnam', '0201100021', 'UK-Vietnam Free Trade Agreement');
+    cy.rooReqMetEx('Exporting', 'the UK', '0201100021', 'UK-Vietnam Free Trade Agreement');
+    cy.get('.govuk-list').contains('See valid proofs of origin').click();
+    cy.contains('Valid proofs of origin');
+    cy.get('.govuk-back-link').click();
+
+    cy.get('.govuk-list').contains('See detailed processes and requirements for proving the origin for goods').click();
+    cy.contains('Obtaining and verifying proofs of origin');
+    cy.get('.govuk-back-link').click();
+
+    cy.get('.govuk-list').contains('How proofs of origin are verified').click();
+    cy.contains('Obtaining and verifying proofs of origin');
+    cy.get('.govuk-back-link').click();
   });
 });

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/706-RoO-e2e-WO-directTransport.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/706-RoO-e2e-WO-directTransport.cy.js
@@ -1,0 +1,80 @@
+/* eslint-disable camelcase */
+/* eslint-disable max-len */
+describe('| RoO-e2e-WhollyObtained-DirectTransport.spec | WO + Direct Transport |', function() {
+  it('Import - WO + Direct Transport - Chile', function() {
+    cy.visit('/commodities/0701909090?country=CL#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Chile', 'import');
+    // How Originating is defined
+    cy.howOrginating('Chile', 'UK-Chile Association Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-Chile Association Agreement');
+    // what components ?
+    cy.whatComponents('UK-Chile Association Agreement');
+    // Wholly Obtained yes/no ?
+    cy.whollyObtained('Chile', 'yes');
+    // Origin requirements met
+    cy.originMet('Chile', '0701909090', 'UK-Chile Association Agreement');
+    // Verify Direct Transport link
+    cy.directTransport('UK-Chile Association Agreement');
+  });
+  it('Export - WO + Direct Transport - Albania', function() {
+    cy.visit('/commodities/0702000007?country=AL#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Albania', 'export');
+    // How Originating is defined
+    cy.howOrginating('United Kingdom', 'UK-Albania Partnership, Trade and Cooperation Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-Albania Partnership, Trade and Cooperation Agreement');
+    // what components ?
+    cy.whatComponents('UK-Albania Partnership, Trade and Cooperation Agreement');
+    // Wholly Obtained yes/no ?
+    cy.whollyObtained('the UK', 'yes');
+    // Origin requirements met for export
+    cy.rooReqMetEx('Exporting', 'the UK', '0702000007', 'UK-Albania Partnership, Trade and Cooperation Agreement');
+    // Verify Direct Transport link
+    cy.directTransport('UK-Albania Partnership, Trade and Cooperation Agreement');
+  });
+  it('Import - No Direct Transport link on RoO not met screen and valid proofs of origin pages - Iceland', function() {
+    cy.visit('/commodities/0702000007?country=IS#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Iceland', 'import');
+    // How Originating is defined
+    cy.howOrginating('Iceland', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // what components ?
+    cy.whatComponents('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Wholly Obtained yes/no ?
+    cy.whollyObtained('Iceland', 'no');
+    // Origin requirements not met for import
+    cy.rooNotMetImp('Importing', 'Iceland', '0702000007', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Verify Direct Transport link
+    cy.should('not.contain.text', 'Find out about the direct transport rule');
+  });
+  it('Export - No Direct Transport link on RoO not met screen and valid proofs of origin pages - Iceland', function() {
+    cy.visit('/commodities/0702000007?country=IS#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Iceland', 'export');
+    // How Originating is defined
+    cy.howOrginating('United Kingdom', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // what components ?
+    cy.whatComponents('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Wholly Obtained yes/no ?
+    cy.whollyObtained('the UK', 'no');
+    // Origin requirements not met for exporting
+    cy.rooNotMetImp('Exporting', 'the UK', '0702000007', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Verify Direct Transport link
+    cy.should('not.contain.text', 'Find out about the direct transport rule');
+  });
+});

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/707-RoO-e2e-WO-nonAlteration.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/707-RoO-e2e-WO-nonAlteration.cy.js
@@ -1,0 +1,80 @@
+/* eslint-disable camelcase */
+/* eslint-disable max-len */
+describe('| RoO-e2e-WhollyObtained-NonAlteration.spec | WO + Non Alteration |', function() {
+  it('Import - WO + Non Alteration - Japan', function() {
+    cy.visit('/commodities/1602321110?country=JP#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Japan', 'import');
+    // How Originating is defined
+    cy.howOrginating('Japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-Japan Comprehensive Economic Partnership Agreement');
+    // what components ?
+    cy.whatComponents('UK-Japan Comprehensive Economic Partnership Agreement');
+    // Wholly Obtained yes/no ?
+    cy.whollyObtained('Japan', 'yes');
+    // Origin requirements met
+    cy.originMet('Japan', '1602321110', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // Verify Non Alteration link
+    cy.nonAlteration('Japan');
+  });
+  it('Export - WO + Non Alteration - Japan', function() {
+    cy.visit('/commodities/1602321110?country=JP#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Japan', 'export');
+    // How Originating is defined
+    cy.howOrginating('United Kingdom', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-Japan Comprehensive Economic Partnership Agreement');
+    // what components ?
+    cy.whatComponents('UK-Japan Comprehensive Economic Partnership Agreement');
+    // Wholly Obtained yes/no ?
+    cy.whollyObtained('the UK', 'yes');
+    // Origin requirements met for export
+    cy.rooReqMetEx('Exporting', 'the UK', '1602321110', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // Verify Non Alteration link
+    cy.nonAlteration('Japan');
+  });
+  it('Import - No Non Alteration link on RoO not met screen and valid proofs of origin pages - Iceland', function() {
+    cy.visit('/commodities/0702000007?country=IS#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Iceland', 'import');
+    // How Originating is defined
+    cy.howOrginating('Iceland', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // what components ?
+    cy.whatComponents('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Wholly Obtained yes/no ?
+    cy.whollyObtained('Iceland', 'no');
+    // Origin requirements not met for import
+    cy.rooNotMetImp('Importing', 'Iceland', '0702000007', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Verify Non Alteration link
+    cy.should('not.contain.text', 'Find out about the non-alternation rule');
+  });
+  it('Export - No Non Alteration link on RoO not met screen and valid proofs of origin pages - Iceland', function() {
+    cy.visit('/commodities/0702000007?country=IS#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Iceland', 'export');
+    // How Originating is defined
+    cy.howOrginating('United Kingdom', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // what components ?
+    cy.whatComponents('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Wholly Obtained yes/no ?
+    cy.whollyObtained('the UK', 'no');
+    // Origin requirements not met for exporting
+    cy.rooNotMetImp('Exporting', 'the UK', '0702000007', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Verify Non Alteration link
+    cy.should('not.contain.text', 'Find out about the non-alternation rule');
+  });
+});

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/708-RoO-e2e-WO-SuffPro-ProdSpecRules.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/708-RoO-e2e-WO-SuffPro-ProdSpecRules.cy.js
@@ -18,7 +18,7 @@ describe('| 707-RoO-e2e-WO-SuffPro-ProdSpecRules | WO + SuffPro + Product Specfi
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Japan');
     // cumulation
-    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.cumulation('japan', '1602321110', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'yes');
     // product specific rules
     cy.prodSpecificRules('A maximum of 60% of the ex-works price (EXW) is made up of non-originating parts (MaxNOM).');
@@ -42,7 +42,7 @@ describe('| 707-RoO-e2e-WO-SuffPro-ProdSpecRules | WO + SuffPro + Product Specfi
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Iceland');
     // cumulation
-    cy.cumulation('iceland-norway', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    cy.cumulation('iceland-norway', '6101201000', 'IS', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
     cy.minimalOps('Agreement on Trade in Goods between Iceland, Norway and the UK', 'yes');
     // moreInfoAboutProduct
     cy.moreInfoAboutProduct('6101201000', 'Articles of apparel and clothing accessories, knitted or crocheted: ➔ Other');

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/708-RoO-e2e-WO-SuffPro-ProdSpecRules.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/708-RoO-e2e-WO-SuffPro-ProdSpecRules.cy.js
@@ -1,0 +1,63 @@
+/* eslint-disable camelcase */
+/* eslint-disable max-len */
+describe('| 707-RoO-e2e-WO-SuffPro-ProdSpecRules | WO + SuffPro + Product Specfic Rules |', function() {
+  it('Importing - NWO + One Scheme + Insufficient processing + product specific rules - Japan', function() {
+    cy.visit('/commodities/1602321110?country=JP#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Japan', 'import');
+    // How Originating is defined
+    cy.howOrginating('Japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-Japan Comprehensive Economic Partnership Agreement');
+    // what components
+    cy.whatComponents('UK-Japan Comprehensive Economic Partnership Agreement');
+    // Wholly Obtained ?
+    cy.whollyObtained('Japan', 'no');
+    // Your goods are not wholly obtained
+    cy.notWhollyObtained('Japan');
+    // cumulation
+    cy.cumulation('japan', 'UK-Japan Comprehensive Economic Partnership Agreement');
+    cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'yes');
+    // product specific rules
+    cy.prodSpecificRules('A maximum of 60% of the ex-works price (EXW) is made up of non-originating parts (MaxNOM).');
+    // Origin requirements met
+    cy.originMet('Japan', '1602321110', 'UK-Japan Comprehensive Economic Partnership Agreement');
+  });
+  it.only('Importing - NWO + One Scheme + product specific rules - Iceland', function() {
+    cy.visit('/commodities/6101201000?country=IS#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('Iceland', 'import');
+    // How Originating is defined
+    cy.howOrginating('Iceland', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // what components
+    cy.whatComponents('Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // Wholly Obtained ?
+    cy.whollyObtained('Iceland', 'no');
+    // Your goods are not wholly obtained
+    cy.notWhollyObtained('Iceland');
+    // cumulation
+    cy.cumulation('iceland-norway', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    cy.minimalOps('Agreement on Trade in Goods between Iceland, Norway and the UK', 'yes');
+    // moreInfoAboutProduct
+    cy.moreInfoAboutProduct('6101201000', 'Articles of apparel and clothing accessories, knitted or crocheted: ➔ Other');
+    // prodSpecRules
+    cy.prodSpecRules('Manufacture from :');
+    // Origin requirements met
+    cy.originMet('Iceland', '6101201000', 'Agreement on Trade in Goods between Iceland, Norway and the UK');
+    cy.contains('Product-specific rules met');
+    cy.contains('Importing commodity 6101201000 from Iceland to the UK');
+    cy.contains('Based on your responses, your product appears to meet the rules of origin requirements for the Agreement on Trade in Goods between Iceland, Norway and the UK');
+    // links
+    cy.get('.govuk-list').contains('See valid proofs of origin').click();
+    cy.contains('Valid proofs of origin');
+    cy.get('.govuk-list').contains('How proofs of origin are verified').click();
+    // proof verification
+    cy.proofVerification('Iceland');
+  });
+});

--- a/cypress/support/rooCommands.js
+++ b/cypress/support/rooCommands.js
@@ -99,6 +99,14 @@ Cypress.Commands.add('originMet', (country, code, agreement)=>{
   cy.get('.govuk-back-link').click();
 });
 
+// proof verification
+Cypress.Commands.add('proofVerification', (country)=>{
+  cy.contains('Obtaining and verifying proofs of origin');
+  cy.contains(`Verification for proving the origin for goods coming from ${country}`);
+  cy.contains('Refer to the full text of the Origin Reference Document').click();
+  cy.get('.downloadable-document__text').contains('Articles 32 and 33 ');
+});
+
 // Duty drawback stage into the RoO journey
 Cypress.Commands.add('dutyDrawback', (country, agreement)=>{
   cy.get('.govuk-list').contains('Find out about duty drawback').click();
@@ -109,6 +117,26 @@ Cypress.Commands.add('dutyDrawback', (country, agreement)=>{
   cy.contains('Duty drawback - an example');
   cy.contains('The provision of duty drawback depends on the specifics of the trade agreement.');
   cy.contains(`Prohibition of drawback of, or exemption from, customs duties according to the ${agreement}`);
+  cy.get('.govuk-back-link').click();
+});
+
+// Direct Transport rule validation
+Cypress.Commands.add('directTransport', (agreement)=>{
+  cy.get('.govuk-list').contains('Find out about the direct transport rule').click();
+  cy.contains('Obtaining and verifying proofs of origin');
+  cy.contains(`Direct transport rule for ${agreement}`);
+  cy.contains('The purpose of the direct transport rule is to ensure that the goods arriving in the country of import are the same as those which left the country of export without alteration.');
+  cy.contains('Refer to the full text of the Origin Reference Document');
+  cy.get('.govuk-back-link').click();
+});
+
+// Direct Transport rule validation
+Cypress.Commands.add('nonAlteration', (country)=>{
+  cy.get('.govuk-list').contains('Find out about the non-alteration rule').click();
+  cy.contains('Obtaining and verifying proofs of origin');
+  cy.contains(`Non-alteration rule for trade with ${country}`);
+  cy.contains('The purpose of the non-alteration rule is to ensure that the goods arriving in the country of import are the same as those which left the country of export without alteration.');
+  cy.contains('Refer to the full text of the Origin Reference Document');
   cy.get('.govuk-back-link').click();
 });
 
@@ -147,6 +175,25 @@ Cypress.Commands.add('minimalOps', (scheme, selection)=>{
   cy.contains(`'Insufficient processing' operations according to the ${scheme}`);
   cy.contains('Have non-originating parts been subject to sufficient processing to qualify for preferential treatment?');
   cy.get(`#rules-of-origin-steps-sufficient-processing-sufficient-processing-${selection}-field`).check();
+  cy.get('.govuk-button').contains('Continue').click();
+});
+
+// product-specific rules
+Cypress.Commands.add('prodSpecificRules', (rule)=>{
+  cy.contains('Do your goods meet the product-specific rules?');
+  cy.contains('Your goods must meet one of these rules in order to qualify for originating status. Select an option to indicate if you meet the rule.');
+  cy.contains('CC except from chapter 2.');
+  cy.get('div.govuk-radios > div:nth-child(1) > label > p > a').should('have.attr', 'href', '/chapters/02');
+  cy.contains('A maximum of 60% of the ex-works price (EXW) is made up of non-originating parts (MaxNOM).');
+  cy.get('div.govuk-radios > div:nth-child(2) > label > p > a').should('have.attr', 'href', '/glossary/exw');
+  cy.get('div.govuk-radios > div:nth-child(2) > label > p > a:nth-child(3)').should('have.attr', 'href', '/glossary/max_nom');
+  cy.contains('Your goods contain a Regional Value Content (RVC) of at least 45% of the Free on Board (FOB) cost of the goods.');
+  cy.get('div.govuk-radios > div:nth-child(3) > label > p > a').should('have.attr', 'href', '/glossary/rvc');
+  cy.get('div.govuk-radios > div:nth-child(3) > label > p > a:nth-child(3)').should('have.attr', 'href', '/glossary/fob');
+  cy.contains('Your goods do not meet any of these rules.');
+  cy.contains('Introductory notes to the product-specific rules');
+  cy.contains('About this commodity code');
+  cy.contains(`${rule}`).click();
   cy.get('.govuk-button').contains('Continue').click();
 });
 
@@ -280,7 +327,11 @@ Cypress.Commands.add('rooNotMetGSP', (country, code, scheme)=>{
 });
 // Origin not met non GSP-multipleAgreements
 Cypress.Commands.add('rooNotMetMulti', (trade_selection, country, code, scheme)=>{
-  cy.contains(`${trade_selection} commodity ${code} from ${country}`);
+  if (`${trade_selection}` === 'Exporting') {
+    cy.contains(`${trade_selection} commodity ${code} from the UK to ${country}`);
+  } else {
+    cy.contains(`${trade_selection} commodity ${code} from ${country}`);
+  }
   cy.contains('Product-specific rules not met');
   cy.contains(`Your product does not appear to meet the rules of origin requirements for the ${scheme}.`);
   cy.contains('Based on your answers, it is likely that your product does not class as ‘originating’ and cannot benefit from preferential tariff treatment under the agreement.');

--- a/cypress/support/rooCommands.js
+++ b/cypress/support/rooCommands.js
@@ -158,13 +158,15 @@ Cypress.Commands.add('notWhollyObtained', (country)=>{
   cy.get('.govuk-button').contains('Continue').click();
 });
 // including parts
-Cypress.Commands.add('cumulation', (country, scheme)=>{
+Cypress.Commands.add('cumulation', (country, code, country_short_name, scheme)=>{
   cy.contains('Are your goods originating?');
   cy.contains('Including parts or components from other countries');
   cy.contains('In order to qualify for preferential treatment, you may be able to include parts that come from other countries. This depends on the cumulation rules of the trade agreement, which are described below.');
   cy.contains(`Methods of cumulation in the ${scheme}`);
   cy.contains(`Map showing countries where cumulation may apply to the ${scheme}`);
   cy.get('form#edit_rules_of_origin_steps_cumulation_cumulation  a[target=\'_blank\']').should('have.attr', 'href', `/cumulation_maps/${country}.png`);
+  cy.contains('Bilateral cumulation - an example').click();
+  cy.contains('insufficient processing clause').should('have.attr', 'href', `/rules_of_origin/${code}/${country_short_name}/sufficient_processing`);
   cy.get('.govuk-button').contains('Continue').click();
 });
 // form#edit_rules_of_origin_steps_cumulation_cumulation > img


### PR DESCRIPTION
### Jira link

- [HOTT-2201](https://transformuk.atlassian.net/browse/HOTT-2201)
- [HOTT-2202](https://transformuk.atlassian.net/browse/HOTT-2202)
- [HOTT-2203](https://transformuk.atlassian.net/browse/HOTT-2203)
- [HOTT-2203](https://transformuk.atlassian.net/browse/HOTT-2204)
- [HOTT-2156](https://transformuk.atlassian.net/browse/HOTT-2156)
- [HOTT-2175](https://transformuk.atlassian.net/browse/HOTT-2175)
- [HOTT-2190](https://transformuk.atlassian.net/browse/HOTT-2190)
- [HOTT-2030](https://transformuk.atlassian.net/browse/HOTT-2030)

### What?

I have added/removed/altered the following:

- Added new automated spec files for non-alteration and direct transport test cases.
- Added new tests for product-specific rules verification and glossary links
- Refactored old tests as per new Rules of Origin changes
- Enabled a few skipped tests and updated changes accordingly

### Why?

I am doing this because:

- New automated tests should be added to run as part of regression tests when new features or functionality changes are implemented.