### PR TITLE
adding a new tag to skip RoO specs execution on production

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       CYPRESS_BASE_URL: "https://www.trade-tariff.service.gov.uk"
       CYPRESS_SPACE: "PRODUCTION"
-      CYPRESS_grepTags: "-devOnly+-smokeTest"
+      CYPRESS_grepTags: "-devOnly+-smokeTest+-notProduction"
     name: "🚦 Regression Tests - UK and XI"
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -14,7 +14,7 @@ jobs:
       CYPRESS_DEVELOPMENT_BASIC_AUTH: ${{ secrets.CYPRESS_DEVELOPMENT_BASIC_AUTH }}
       CYPRESS_DEVELOPMENT_BASIC_PASSWORD: ${{ secrets.CYPRESS_DEVELOPMENT_BASIC_PASSWORD }}
       CYPRESS_DEVELOPMENT_BASIC_USERNAME: ${{ secrets.CYPRESS_DEVELOPMENT_BASIC_USERNAME }}
-      CYPRESS_grepTags: "devOnly+-smokeTest"
+      CYPRESS_grepTags: "devOnly+-smokeTest+-notDevelopment"
     name: "RegressionTests - Development - Features"
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -14,7 +14,7 @@ jobs:
       CYPRESS_STAGING_BASIC_AUTH: ${{ secrets.CYPRESS_STAGING_BASIC_AUTH }}
       CYPRESS_STAGING_BASIC_PASSWORD: ${{ secrets.CYPRESS_STAGING_BASIC_PASSWORD }}
       CYPRESS_STAGING_BASIC_USERNAME: ${{ secrets.CYPRESS_STAGING_BASIC_USERNAME }}
-      CYPRESS_grepTags: "-devOnly+-smokeTest"
+      CYPRESS_grepTags: "-devOnly+-smokeTest+-notStaging"
     name: " 🛎️ RegressionTests - UK and XI - Staging "
     runs-on: ubuntu-18.04
     strategy:

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/601-RoO-e2e-NWO-GSP-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/601-RoO-e2e-NWO-GSP-InsuffPro.cy.js
@@ -1,6 +1,6 @@
 // NWO- GSP Scheme_Insufficient processing
 // ONLY IMPORT JOURNEY
-describe('| 601-RoO-e2e-NWO-GSP-InsuffProcess.spec | NWO + GSP Scheme + insufficient processing |', function() {
+describe('| 601-RoO-e2e-NWO-GSP-InsuffProcess.spec | NWO + GSP Scheme + insufficient processing |', {tags: ['notProduction']}, function() {
   it('Importing - NWO + GSP Scheme + insufficient processing - Bangladesh + PSR', function() {
     cy.visit('/commodities/5808100000?country=BD#rules-of-origin');
     cy.checkRoO();

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.cy.js
@@ -3,7 +3,7 @@
 /* eslint-disable max-len */
 // NWO + Multi-NonGSP + Insufficient processing = RoO Not met
 //
-describe('| 602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.spec | NWO + Multi-NonGSP + Insufficient processing |', function() {
+describe('| 602-RoO-e2e-NWO-MultiSchm-NonGSP-InsuffPro.spec | NWO + Multi-NonGSP + Insufficient processing |', {tags: ['notProduction']}, function() {
   const trade_type = ['import', 'export'];
   const trade_country = ['Vietnam', 'United Kingdom'];
   const trade_country2 = ['Vietnam', 'the UK'];

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/603-RoO-e2e-NWO-MultiSchm-NonGSP-SuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/603-RoO-e2e-NWO-MultiSchm-NonGSP-SuffPro.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 // NWO + Multi-NonGSP + Sufficient processing + SubDivision + PSR
 //
-describe('| RoO-e2e-NWO-MultiSchm-NonGSP-SuffPro.spec | NWO + Multi-NonGSP + Sufficient processing + SubDivision + PSR  |', function() {
+describe('| RoO-e2e-NWO-MultiSchm-NonGSP-SuffPro.spec | NWO + Multi-NonGSP + Sufficient processing + SubDivision + PSR  |', {tags: ['notProduction']}, function() {
   it('Importing - NWO + Multi-NonGSP + Sufficient processing  + Vietnam + Prod specific rules - Yes/No', function() {
     cy.visit('/commodities/6004100091?country=VN#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/604-RoO-e2e-NWO-OneSchm-InsuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/604-RoO-e2e-NWO-OneSchm-InsuffPro.cy.js
@@ -1,6 +1,6 @@
 // NWO-One Scheme_Insufficient processing
 // WO - one scheme
-describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient processing |', function() {
+describe('| RoO-e2e-NWO-OneSchm-InsuffPro.spec | NWO + One Scheme + insufficient processing |', {tags: ['notProduction']}, function() {
   it('Importing - NWO + One Scheme + Insufficient processing - Japan', function() {
     cy.visit('/commodities/5808100000?country=JP#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/605-RoO-e2e-NWO-OneSchm-SuffPro-subdiv.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/605-RoO-e2e-NWO-OneSchm-SuffPro-subdiv.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 // NWO-One Scheme_Insufficient processing
 // WO - one scheme
-describe('| RoO-e2e-NWO-OneSchm-SuffPro-subdiv.spec | NWO + One Scheme + Sufficient processing +  |', function() {
+describe('| RoO-e2e-NWO-OneSchm-SuffPro-subdiv.spec | NWO + One Scheme + Sufficient processing |', {tags: ['notProduction']}, function() {
   it('Importing - NWO + One Scheme + Sufficient processing + Botswana + Subdivision + Prod specific rules - Yes/No', function() {
     cy.visit('/commodities/5208121620?country=BW#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/606-RoO-e2e-NWO-OneSchm-SuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/606-RoO-e2e-NWO-OneSchm-SuffPro.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 // NWO-One Scheme_Insufficient processing
 // WO - one scheme
-describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient processing +  |', function() {
+describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient processing |', {tags: ['notProduction']}, function() {
   it('Importing - NWO + One Scheme + Sufficient processing + Japan + Prod specific rules - Yes/No', function() {
     cy.visit('/commodities/6004100091?country=JP#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/701-RoO-e2e-WO-GSP.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/701-RoO-e2e-WO-GSP.cy.js
@@ -1,5 +1,5 @@
 // WO + GSP Scheme - Bangladesh
-describe('| RoO-e2e-WhollyObtained-GSP.spec | WO + GSP Scheme - Bangladesh |', function() {
+describe('| RoO-e2e-WhollyObtained-GSP.spec | WO + GSP Scheme - Bangladesh |', {tags: ['notProduction']}, function() {
   it('Import - WO + GSP Scheme - Bangladesh', function() {
     cy.visit('/commodities/0201100021?country=BD#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/702-RoO-e2e-WO-Multi-GSP.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/702-RoO-e2e-WO-Multi-GSP.cy.js
@@ -1,5 +1,5 @@
 // WO - Multiple schemes - GSP
-describe('| RoO-e2e-WO-Multiple-GSP.spec | WO + Multiple Schemes + GSP - Vietnam |', function() {
+describe('| RoO-e2e-WO-Multiple-GSP.spec | WO + Multiple Schemes + GSP - Vietnam |', {tags: ['notProduction']}, function() {
   it('Import - WO + Multiple Schemes + GSP - Vietnam', function() {
     cy.visit('/commodities/0201100021?country=VN#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/703-RoO-e2e-WO-Multi-nonGSP.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/703-RoO-e2e-WO-Multi-nonGSP.cy.js
@@ -1,5 +1,5 @@
 // WO - Multiple schemes - nonGSP
-describe('| RoO-e2e-WO-Multiple-nonGSP.spec | WO + Multiple Schemes + nonGSP - Vietnam |', function() {
+describe('| RoO-e2e-WO-Multiple-nonGSP.spec | WO + Multiple Schemes + nonGSP - Vietnam |', {tags: ['notProduction']}, function() {
   it('Import - WO + Multiple Schemes + GSP - Vietnam', function() {
     cy.visit('/commodities/0201100021?country=VN#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/704-RoO-e2e-WO-OneSchm.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/704-RoO-e2e-WO-OneSchm.cy.js
@@ -1,5 +1,5 @@
 // WO - one scheme
-describe('| RoO-e2e-WhollyObtained-OneScheme.spec | WO + One Scheme |', function() {
+describe('| RoO-e2e-WhollyObtained-OneScheme.spec | WO + One Scheme |', {tags: ['notProduction']}, function() {
   it('WO+One Scheme - South Africa', function() {
     cy.visit('/commodities/0201100021?country=ZA#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/705-RoO-e2e-WO-dutyDrawback.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/705-RoO-e2e-WO-dutyDrawback.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 /* eslint-disable max-len */
 // WO + Duty Drawback
-describe('| RoO-e2e-WhollyObtained-DutyDrawback.spec | WO + Duty Drawback |', function() {
+describe('| RoO-e2e-WhollyObtained-DutyDrawback.spec | WO + Duty Drawback |', {tags: ['notProduction']}, function() {
   it('Import - WO + Duty Drawback - Chile', function() {
     cy.visit('/commodities/0701909090?country=CL#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/706-RoO-e2e-WO-directTransport.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/706-RoO-e2e-WO-directTransport.cy.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /* eslint-disable max-len */
-describe('| RoO-e2e-WhollyObtained-DirectTransport.spec | WO + Direct Transport |', function() {
+describe('| RoO-e2e-WhollyObtained-DirectTransport.spec | WO + Direct Transport |', {tags: ['notProduction']}, function() {
   it('Import - WO + Direct Transport - Chile', function() {
     cy.visit('/commodities/0701909090?country=CL#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/707-RoO-e2e-WO-nonAlteration.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/707-RoO-e2e-WO-nonAlteration.cy.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /* eslint-disable max-len */
-describe('| RoO-e2e-WhollyObtained-NonAlteration.spec | WO + Non Alteration |', function() {
+describe('| RoO-e2e-WhollyObtained-NonAlteration.spec | WO + Non Alteration |', {tags: ['notProduction']}, function() {
   it('Import - WO + Non Alteration - Japan', function() {
     cy.visit('/commodities/1602321110?country=JP#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/708-RoO-e2e-WO-SuffPro-ProdSpecRules.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-WhollyObtained/708-RoO-e2e-WO-SuffPro-ProdSpecRules.cy.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 /* eslint-disable max-len */
-describe('| 707-RoO-e2e-WO-SuffPro-ProdSpecRules | WO + SuffPro + Product Specfic Rules |', function() {
+describe('| 707-RoO-e2e-WO-SuffPro-ProdSpecRules | WO + SuffPro + Product Specfic Rules |', {tags: ['notProduction']}, function() {
   it('Importing - NWO + One Scheme + Insufficient processing + product specific rules - Japan', function() {
     cy.visit('/commodities/1602321110?country=JP#rules-of-origin');
     // click Check Rules of Origin button

--- a/cypress/e2e/RulesOfOrigin/additionalDutiesBoxConditionalRulesRoO.cy.js
+++ b/cypress/e2e/RulesOfOrigin/additionalDutiesBoxConditionalRulesRoO.cy.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 // eslint-disable-next-line max-len
-describe('| additionalDutiesBoxConditionalRulesRoO.spec - Rules of Origin tab - additional duties box conditional rules', function() {
+describe('| additionalDutiesBoxConditionalRulesRoO.spec - Rules of Origin tab - additional duties box conditional rules', {tags: ['notProduction']}, function() {
   it(`| UK | Third country duty (MFN) is 0.0%, and there is a preference or a quota |`, function() {
     cy.visit(`/commodities/0102211000?country=ZA#rules-of-origin`);
     cy.contains('Rules of origin').click();

--- a/cypress/e2e/RulesOfOrigin/impTradeSumBoxRoOTab.cy.js
+++ b/cypress/e2e/RulesOfOrigin/impTradeSumBoxRoOTab.cy.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable new-cap */
 /* eslint-disable max-len */
-describe('| impTradeSumBoxRoOTab.spec.spec - Rules of Origin tab - Logic for duties box', {tags: ['config', 'roo-tag']}, function() {
+describe('| impTradeSumBoxRoOTab.spec.spec - Rules of Origin tab - Logic for duties box', {tags: ['config', 'roo-tag', 'notProduction']}, function() {
   it(`| UK | Preference + Quota |`, function() {
     cy.visit(`commodities/0203111000?country=PE#rules-of-origin`);
     cy.contains('Rules of origin').click();

--- a/cypress/e2e/RulesOfOrigin/importExportPageRoO.cy.js
+++ b/cypress/e2e/RulesOfOrigin/importExportPageRoO.cy.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-describe('importExportPageRoO.spec | Rules of Origin Import/Export , Import only page', function() {
+describe('importExportPageRoO.spec | Rules of Origin Import/Export , Import only page', {tags: ['notProduction']}, function() {
   it('UK - Page validations - Japan - Import/Export page', function() {
     cy.visit('/commodities/6004100091?country=JP#rules-of-origin');
     cy.contains('Work out if your goods meet the rules of origin');

--- a/cypress/e2e/RulesOfOrigin/importOnlyPageRoO.cy.js
+++ b/cypress/e2e/RulesOfOrigin/importOnlyPageRoO.cy.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-describe('importOnlyPageRoO.spec.js | Rules of Origin Import only page', function() {
+describe('importOnlyPageRoO.spec.js | Rules of Origin Import only page', {tags: ['notProduction']}, function() {
   it('UK - Page validations - Afghanistan - Import only page', function() {
     cy.visit('/commodities/6004100091?country=AF#rules-of-origin');
     cy.contains('Work out if your goods meet the rules of origin');


### PR DESCRIPTION
Jira link

- adding a new tag to skip RoO specs execution on production.

What?
I have added/removed/altered the following:

- Updated RoO spec files with new tags: notProduction, notStaging and notdevelopment to skip execution of spec files on a particular environment.
- Executed regression tests on my local machine, went through each regression failure spec file and managed to fix some of the tests.

Why?
I am doing this because:

- Working towards making regression tests 100% green across all environments.