### PR TITLE
update tags to skip new API spec file execution for production

### DIFF
--- a/cypress/e2e/UK/API/V2/checkValidityPeriodsV2api-UK.cy.js
+++ b/cypress/e2e/UK/API/V2/checkValidityPeriodsV2api-UK.cy.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-describe('🇬🇧 checkValidityPeriodsV2api-UK| Validaity start and end dates for APIs', {tags: ['notDevelopment, notProduction']}, function() {
+describe('🇬🇧 checkValidityPeriodsV2api-UK| Validaity start and end dates', {tags: ['notDevelopment', 'notProduction']}, function() {
   it('UK - Sections API - Verify validity start and end dates for chapters', function() {
     cy.request('/api/v2/sections/01')
         .then((response) => {


### PR DESCRIPTION
Jira link

- [HOTT-2071] (https://transformuk.atlassian.net/browse/HOTT-2071)
- [HOTT-2182] (https://transformuk.atlassian.net/browse/HOTT-2182)
- [HOTT-2183] (https://transformuk.atlassian.net/browse/HOTT-2183)
- [HOTT-2184] (https://transformuk.atlassian.net/browse/HOTT-2184)
- [HOTT-2218] (https://transformuk.atlassian.net/browse/HOTT-2218)

What?
I have added/removed/altered:

- Updated tags to skip execution of new API spec file during the production regression test.

Why?
I am doing this because:

- It would be good to add new regression tests for new changes for the backend to validate and ensure that the specific changes are available in the API response.