### PR TITLE
update measure 464 tests

### DIFF
--- a/cypress/e2e/HOTT-Shared/importDuties.cy.js
+++ b/cypress/e2e/HOTT-Shared/importDuties.cy.js
@@ -28,9 +28,8 @@ Move reassigned measure types (464, 481, 482, 483) from 'hide me' to import duti
       cy.visit(`${country[i]}/commodities/8714999011#import`);
       cy.contains(`${titles[i]}`);
       cy.contains('Import duties').click();
-      cy.contains('Declaration of subheading submitted to authorised use provisions').should('not.exist');
-      // cy.contains('CD501').click();
-      // cy.contains('Declaration of subheading submitted to authorised use provisions');
+      cy.contains('China (CN)');
+      cy.contains('Declaration of subheading submitted to authorised use provisions');
     });
   }
   it('UK Import duties 489', function() {


### PR DESCRIPTION
Jira link

- HOTT-<2254> [https://transformuk.atlassian.net/browse/HOTT-2254]

What?
I have added/removed/altered the following:

- Updated measure 464 related tests as per HOTT-2254 ticket changes to avoid failures in the regression suite.

Why?
I am doing this because:

- It would be good to update the spec files as per new changes to avoid failures.