### PR TITLE
HOTT-2230: Enable beta search specs on staging and production

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -1,4 +1,4 @@
-describe('Using beta search', {tags: ['devOnly']}, function() {
+describe('Using beta search', function() {
   it('Search result returns guides for `fresh potatoes`', function() {
     cy.visit('/find_commodity');
     cy.visit('/search/toggle_beta_search');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2230

### What?

I have added/removed/altered:

- [x] Removed development tag from betaSearch tests

### Why?

I am doing this because:

- This is required to prove that the beta search functionality works on staging and production
