### PR TITLE
Update RoO NWO scenario to validate cumulation page changes

### DIFF
--- a/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/606-RoO-e2e-NWO-OneSchm-SuffPro.cy.js
+++ b/cypress/e2e/RulesOfOrigin/RoO-e2e-NotWhollyObtained/606-RoO-e2e-NWO-OneSchm-SuffPro.cy.js
@@ -18,7 +18,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient pro
     cy.whollyObtained('Japan', 'no');
     // Your goods are not wholly obtained
     cy.notWhollyObtained('Japan');
-    // cumulation
+    // cumulation - Bilateral cumulation and Extended cumulation example
     cy.cumulation('japan', '6004100091', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     // min Operations met ?
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'yes');
@@ -48,7 +48,7 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient pro
     cy.whollyObtained('the UK', 'no');
     // Your goods are not wholly obtained
     cy.notWhollyObtained('the UK');
-    // cumulation
+    // cumulation - Bilateral cumulation and Extended cumulation example
     cy.cumulation('japan', '6004100091', 'JP', 'UK-Japan Comprehensive Economic Partnership Agreement');
     // min Operations met ?
     cy.minimalOps('UK-Japan Comprehensive Economic Partnership Agreement', 'yes');
@@ -125,5 +125,37 @@ describe('| RoO-e2e-NWO-OneSchm-SuffPro.spec | NWO + One Scheme + Sufficient pro
     cy.prodSpecRules('Your goods do not meet any of these rules.');
     // Origin requirements NOT met
     cy.rooNotMet('Importing', 'Egypt', '0502100000', 'UK-Egypt Association Agreement');
+  });
+  it('Importing - NWO + Diagonal Cumulation Example + South Korea + Prod Specific Rules Met', function() {
+    cy.visit('/commodities/1702201010?country=KR#rules-of-origin');
+    // click Check Rules of Origin button
+    cy.checkRoO();
+    // Import
+    cy.impOrExp('South Korea', 'import');
+    // How Originating is defined
+    cy.howOrginating('South Korea', 'UK-South Korea Trade Agreement');
+    // How wholly obtained is defined
+    cy.howWhollyObtained('UK-South Korea Trade Agreement');
+    // what components
+    cy.whatComponents('UK-South Korea Trade Agreement');
+    // Wholly Obtained ?
+    cy.whollyObtained('South Korea', 'no');
+    // Your goods are not wholly obtained
+    cy.notWhollyObtained('South Korea');
+    // cumulation - Bilateral cumulation and Diagonal cumulation example
+    cy.cumulation('south-korea', '1702201010', 'KR', 'UK-South Korea Trade Agreement');
+    // min Operations met ?
+    cy.minimalOps('UK-South Korea Trade Agreement', 'yes');
+    // Provide more information about your product
+    cy.moreInfoAboutProduct('1702201010', 'Sugars and sugar confectionery');
+    // product specific rules?
+    cy.prodSpecRules('Manufacture from materials of any heading, except that of the product.');
+    // Origin requirements met
+    cy.rooReqMet('Importing', 'South Korea', '1702201010', 'UK-South Korea Trade Agreement');
+    // Validate if product specific rules are met
+    cy.go(-1);
+    cy.prodSpecRules('Your goods do not meet any of these rules.');
+    // Origin requirements NOT met
+    cy.rooNotMet('Importing', 'South Korea', '1702201010', 'UK-South Korea Trade Agreement');
   });
 });

--- a/cypress/support/rooCommands.js
+++ b/cypress/support/rooCommands.js
@@ -167,6 +167,13 @@ Cypress.Commands.add('cumulation', (country, code, country_short_name, scheme)=>
   cy.get('form#edit_rules_of_origin_steps_cumulation_cumulation  a[target=\'_blank\']').should('have.attr', 'href', `/cumulation_maps/${country}.png`);
   cy.contains('Bilateral cumulation - an example').click();
   cy.contains('insufficient processing clause').should('have.attr', 'href', `/rules_of_origin/${code}/${country_short_name}/sufficient_processing`);
+  if (`${country_short_name}` === 'JP') {
+    cy.contains('Extended cumulation - an example').click();
+    cy.contains('insufficient processing clause').should('have.attr', 'href', `/rules_of_origin/${code}/${country_short_name}/sufficient_processing`);
+  } else if (`${country_short_name}` === 'KR') {
+    cy.contains('Diagonal cumulation - an example').click();
+    cy.should('not.contain.text', 'insufficient processing clause');
+  }
   cy.get('.govuk-button').contains('Continue').click();
 });
 // form#edit_rules_of_origin_steps_cumulation_cumulation > img


### PR DESCRIPTION
Jira link

- HOTT-<2207> [https://transformuk.atlassian.net/browse/HOTT-2207]
- HOTT-<2313> [https://transformuk.atlassian.net/browse/HOTT-2313]

What?
I have added/removed/altered the following:

- Updated RoO not wholly obtained related scenarios for Japan and South Korea to validate the cumulation page changes as per HOTT-2207 and HOTT-2313 tickets.

Why?
I am doing this because:

- To ensure that the regression tests are up to date whenever there are new changes being introduced or altered existing functionalities.