### PR TITLE
HOTT-2081 Fixes for page title changes in HOTT-2081

### DIFF
--- a/cypress/e2e/HOTT-Shared/newsTab.cy.js
+++ b/cypress/e2e/HOTT-Shared/newsTab.cy.js
@@ -6,7 +6,7 @@ describe('| 📰 newsTab.spec.js | news updates page on UK and XI services', fun
     it(`${countries[i]} News page`, function() {
       cy.visit(`${countries[i]}/sections`);
       cy.get('li:nth-of-type(5) > .govuk-header__link').contains('News').click();
-      cy.contains('Latest news');
+      cy.contains('Trade tariff news bulletin');
       cy.contains('Subscribe to the news feed');
     });
   }

--- a/cypress/e2e/UK/FE/pages-UK.cy.js
+++ b/cypress/e2e/UK/FE/pages-UK.cy.js
@@ -101,7 +101,7 @@ describe('🇬🇧 💡 | pages-UK.spec | Main Page - headers ,sections  - (UK v
   it('UK - News section', function() {
     cy.visit('/find_commodity');
     cy.get('li:nth-of-type(5) > .govuk-header__link').click();
-    cy.contains('Latest news');
+    cy.contains('Trade tariff news bulletin');
   });
   // HOTT-164
   it('UK - Remove the link to the EU website for looking up measures, geographical areas and regulations - Main Page ', function() {

--- a/cypress/e2e/XI/FE/pages-XI.cy.js
+++ b/cypress/e2e/XI/FE/pages-XI.cy.js
@@ -98,7 +98,7 @@ describe('🇪🇺 💡 | pages-XI.spec.js | Main Page ,headings ,sections - (XI
   it('XI - News section', function() {
     cy.visit('xi/find_commodity');
     cy.get('li:nth-of-type(5) > .govuk-header__link').click();
-    cy.contains('Latest news');
+    cy.contains('Trade tariff news bulletin');
   });
 
   // HOTT-164


### PR DESCRIPTION
Still includes failures for missing news feed panel - this is because this should be returning next week

### Jira link

HOTT-2081

### What?

I have added/removed/altered:

- [x] Updates for changed page title in news section

### Why?

I am doing this because:

- Because the Stop press UI has a new page title

### Notes

There is still a failing spec for the currently missing feed panel - this is left as a reminder that we need to decide whether to bring that back or not