### PR TITLE
HOTT-2329: Adds tests for beta search reference behaviour

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -3,7 +3,7 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.visit('/find_commodity');
     cy.visit('/search/toggle_beta_search');
     cy.searchForCommodity('fresh potatoes');
-
+    cy.contains('Potatoes, fresh or chilled').click()
     cy.get('.image-guide').should('exist');
 
     cy.get('#search-filter-navigation div div p a').should(
@@ -69,10 +69,10 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.visit('/find_commodity');
     cy.visit('/search/toggle_beta_search');
     cy.searchForCommodity('clothing sets');
-    cy.get('.govuk-accordion__section').eq(0).click();
-    cy.get('a').contains('Women\'s and girls\'').click();
+    cy.contains('Show all sections').click()
+    cy.contains('Women\'s and girls\'').click();
     cy.url().should('include', 'clothing_gender');
-    cy.get('a').contains('Women\'s or girls\' blouses, shirts and shirt-blouses');
+    cy.contains('Women\'s or girls\' blouses, shirts and shirt-blouses');
     cy.get('#search-filter-navigation').contains('Results are filtered by:');
     cy.get('.facet-classifications-tag').contains('[x] Women\'s and girls').click();
     cy.get('.facet-classifications-tag').should('not.exist');
@@ -99,10 +99,10 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.url().should('include', '/chapters/85');
   });
 
-  it('Search result returns the no results page for `nothing`', function() {
+  it('Search result returns the no results page for `flibble`', function() {
     cy.visit('/find_commodity');
     cy.visit('/search/toggle_beta_search');
-    cy.searchForCommodity('nothing');
+    cy.searchForCommodity('flibble');
 
     cy.get('div.govuk-warning-text > strong').contains('There are no results');
 
@@ -136,5 +136,26 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.get('.search-results').contains('Results matching ‘eggs’');
     // on the /search url
     cy.url().should('include', '/search');
+  });
+
+  it('Redirects to search references when they match exactly', function() {
+    // given we're on the beta search page
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    // when we search for a known search reference title
+    cy.searchForCommodity('raw');
+    // then we get redirected to the referenced goods nomenclature
+    cy.url().should('include', '/headings/5201');
+  });
+
+  it('Shows commodity results with matching search reference tokens', function() {
+    // given we're on the beta search page
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    // when we search for a `partial` known search reference title
+    cy.searchForCommodity('cardboard');
+    // then we see results for the search reference token
+    cy.url().should('include', '/search');
+    cy.get('[id^="beta-search-results-"]');
   });
 });


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2329
https://transformuk.atlassian.net/browse/HOTT-2358
https://transformuk.atlassian.net/browse/HOTT-2364

### What?

I have added/removed/altered:

- [x] Added test for exact match search references
- [x] Added test for partial token match search references
- [x] Fixed broken tests that result from more tokens being searchable for commodity documents

### Why?

I am doing this because:

- This is required to make sure we know when these features break. I do expect these tests to a bit rapidly but some coverage is better than none.
