### PR TITLE
HOTT-2373: Adds e2e for searchable intercept terms

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -109,7 +109,7 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.get('#intercept-message')
     // and are shown results
     cy.url().should('include', '/search');
-    cy.get('[id^="beta-search-results-"]');
+    cy.get('#search-result-with-hits');
   });
 
   it('Search result returns the no results page for `flibble`', function() {

--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -99,6 +99,19 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.url().should('include', '/chapters/85');
   });
 
+  it('Searching intercept message term `fitbit` returns results', function() {
+    // given we're on the find commodity page
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    // when we search for a known intercept term which is not included in goods nomenclature descriptions
+    cy.searchForCommodity('fitbit');
+    // then we see an intercept message
+    cy.get('#intercept-message')
+    // and are shown results
+    cy.url().should('include', '/search');
+    cy.get('[id^="beta-search-results-"]');
+  });
+
   it('Search result returns the no results page for `flibble`', function() {
     cy.visit('/find_commodity');
     cy.visit('/search/toggle_beta_search');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2373

Before, when you search for a term that was only in an intercept you'd get:

![Screenshot 2022-12-19 at 11-20-21 UK Integrated Online Tariff Look up commodity codes duty and VAT rates - GOV UK](https://user-images.githubusercontent.com/8156884/208418016-99be1ac3-b830-47aa-8f5d-6c2ec944fcb4.png)

Now we've added intercept terms to the search index for each goods nomenclature we can yield results:

![Screenshot 2022-12-19 at 11-24-39 UK Integrated Online Tariff Look up commodity codes duty and VAT rates - GOV UK](https://user-images.githubusercontent.com/8156884/208418108-d82f2520-2da7-427b-abae-ee00440fde9a.png)

### What?

I have added/removed/altered:

- [x] Added e2e tests for being able to get results for intercept message terms that do not exist in goods nomenclature descriptions

### Why?

I am doing this because:

- This is required to validate the new functionality introduced in the PR https://github.com/trade-tariff/trade-tariff-backend/pull/936
