### PR TITLE
HOTT-2392: Validate search reference redirect behaviour works

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -65,6 +65,13 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.url().should('include', '/commodities/0101210000');
   });
 
+  it('Search redirects for `raw` search reference', function() {
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    cy.searchForCommodity('raw');
+    cy.url().should('include', '/headings/5201');
+  });
+
   it('Search filters results with facet clothing_gender', function() {
     cy.visit('/find_commodity');
     cy.visit('/search/toggle_beta_search');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2392

### What?

I have added/removed/altered:

- [x] Added test to validate search reference redirecting behaviour for beta search

### Why?

I am doing this because:

- This bug would have been discovered earlier
