### PR TITLE
HOTT-2386: Reflect guide updates in beta search specs

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -9,7 +9,7 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.get('#search-filter-navigation div div p a').should(
         'have.attr',
         'href',
-        'https://www.gov.uk/guidance/classifying-edible-fruits-nuts-and-peel',
+        'https://www.gov.uk/guidance/classifying-edible-fruit-vegetables-and-nuts-for-import-and-export',
     );
   });
 


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/HOTT-2383
https://transformuk.atlassian.net/browse/HOTT-2386
https://transformuk.atlassian.net/browse/HOTT-2394

## What?

I have added/removed/altered:

- [x] Reflect updates to guides

## Why?

I am doing this because:

- Guides have been changed (see https://github.com/trade-tariff/trade-tariff-frontend/pull/1249, https://github.com/trade-tariff/trade-tariff-backend/pull/946 and https://github.com/trade-tariff/trade-tariff-backend/pull/940)>
