### PR TITLE
excluding admin tags to run as part of tariff regression

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       CYPRESS_BASE_URL: "https://www.trade-tariff.service.gov.uk"
       CYPRESS_SPACE: "PRODUCTION"
-      CYPRESS_grepTags: "-devOnly+-smokeTest+-notProduction"
+      CYPRESS_grepTags: "-devOnly+-smokeTest+-notProduction+-adminOnly"
     name: "🚦 Regression Tests - UK and XI"
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -14,7 +14,7 @@ jobs:
       CYPRESS_DEVELOPMENT_BASIC_AUTH: ${{ secrets.CYPRESS_DEVELOPMENT_BASIC_AUTH }}
       CYPRESS_DEVELOPMENT_BASIC_PASSWORD: ${{ secrets.CYPRESS_DEVELOPMENT_BASIC_PASSWORD }}
       CYPRESS_DEVELOPMENT_BASIC_USERNAME: ${{ secrets.CYPRESS_DEVELOPMENT_BASIC_USERNAME }}
-      CYPRESS_grepTags: "devOnly+-smokeTest+-notDevelopment"
+      CYPRESS_grepTags: "devOnly+-smokeTest+-notDevelopment+-adminOnly"
     name: "RegressionTests - Development"
     runs-on: ubuntu-18.04
     strategy:

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -14,7 +14,7 @@ jobs:
       CYPRESS_STAGING_BASIC_AUTH: ${{ secrets.CYPRESS_STAGING_BASIC_AUTH }}
       CYPRESS_STAGING_BASIC_PASSWORD: ${{ secrets.CYPRESS_STAGING_BASIC_PASSWORD }}
       CYPRESS_STAGING_BASIC_USERNAME: ${{ secrets.CYPRESS_STAGING_BASIC_USERNAME }}
-      CYPRESS_grepTags: "-devOnly+-smokeTest+-notStaging"
+      CYPRESS_grepTags: "-devOnly+-smokeTest+-notStaging+-adminOnly"
     name: "RegressionTests - Staging"
     runs-on: ubuntu-18.04
     strategy:


### PR DESCRIPTION
### Jira link

NA

### What?

I have added/removed/altered the following:

- Excluded admin tag from the trade tariff regression suite.

### Why?

I am doing this because:

- To avoid running admin specs twice as part of the dev and staging environment workflow.