### PR TITLE
HOTT-2369: Adds test for synonyms with a goods nomenclature item id

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -44,6 +44,13 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.get('.search-results').contains('Meat and edible meat offal');
   });
 
+  it('Search result returns results for synonyms with a goods nomenclature item id', function() {
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    cy.searchForCommodity('hedgehog');
+    cy.get('.search-results').contains('Other live animals');
+  });
+
   it('Search redirects for search heading `0101`', function() {
     cy.visit('/find_commodity');
     cy.visit('/search/toggle_beta_search');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2369
https://github.com/trade-tariff/trade-tariff-backend/pull/1024

![image](https://user-images.githubusercontent.com/8156884/216328870-5f2f1006-9c5f-4284-9842-535241bc678a.png)

### What?

I have added/removed/altered:

- [x] Added a test for a synonym with a goods nomenclature item id

### Why?

I am doing this because:

- This behaviour is required to make sure that synonyms with exact goods nomenclature item ids return the matching nomenclature in their results
