### PR TITLE
Tweak cron of regression nightly workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,44 +44,6 @@ jobs:
               $(git diff --name-only --diff-filter=ACM $(git merge-base main HEAD)..HEAD | grep 'cypress/e2e/' | grep '.cy.js' | tr -s '\n' ',')cypress/e2e/smoketests/smokeTestCI.cy.js
 
 workflows:
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 5 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - cypress/run:
-          executor: custom_chrome
-          context: trade-tariff
-          name: "Scheduled smoke tests on staging"
-          browser: chrome
-          yarn: true
-          post-steps:
-            - slack/notify:
-                channel: tariffs-regression
-                event: fail
-                template: basic_fail_1
-            - slack/notify:
-                channel: tariffs-regression
-                event: pass
-                custom: |
-                  {
-                    "blocks": [
-                      {
-                        "type": "section",
-                        "fields": [
-                          {
-                            "type": "plain_text",
-                            "text": "*Smoke tests passed* :white_check_mark:",
-                            "emoji": true
-                          }
-                        ]
-                      }
-                    ]
-                  }
   ci:
     jobs:
       - test:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,7 +1,7 @@
 name: "| Production | Regression Pack |"
 on:
   schedule:
-    - cron: "00 12 * * *"
+    - cron: "00 00 * * *"
   workflow_dispatch:
 jobs:
   cypress-run:

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -2,7 +2,7 @@ name: "| Development | Regression Pack |"
 
 on:
   schedule:
-    - cron: "00 12 * * *"
+    - cron: "00 00 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -2,7 +2,7 @@ name: "| Staging | Regression Pack |"
 
 on:
   schedule:
-    - cron: "00 12 * * *"
+    - cron: "00 00 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Run regression suites at midnight - not 12 in the afternoon
- [x] Remove redundant nightly smoketest workflow

### Why?

I am doing this because:

- We do not want these to run when the applications are being integrated against by real users
- The nightly smoketest workflow just runs the regression workflow tests so is duplicating
