### PR TITLE
HOTT-2264: Adds admin smoketests

### DIFF
--- a/cypress/e2e/smoketests/adminSmokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/adminSmokeTestCI.cy.js
@@ -1,0 +1,95 @@
+describe('Admin tool smoke tests', {tags: ['adminOnly']}, function() {
+  beforeEach(() => {
+    cy.loginOrRestoreAdminSession();
+  });
+
+  context('when on the UK service', function() {
+    const service = 'uk';
+
+    it('verify sections and chapter notes', function() {
+      cy.verifySectionChapterNotes(service);
+    });
+
+    it('verify section search references', function() {
+      cy.verifySectionSearchReferences(service);
+    });
+
+    it('verify heading search references', function() {
+      cy.verifySearchReferencesHeading(service);
+    });
+
+    it('verify rollbacks', function() {
+      cy.verifyRollbacks(service);
+    });
+
+    it('CRUD a news item', function() {
+      cy.createNewsItem(service);
+      cy.verifyNewsItemOnTariffServices('UK Integrated Online Tariff');
+      cy.verifyAndUpdateNewsItem(service);
+      cy.removeNewsItem(service);
+    });
+
+    it('verify tariff updates', function() {
+      cy.tariffUpdates(service);
+    });
+
+    it('reports', function() {
+      cy.reports(service);
+    });
+
+    it('search quota order number', function() {
+      cy.searchQuotas('058011');
+    });
+
+    it('quota - definitions and balances - exhaustion event', function() {
+      cy.quotaDefinitionsBalances('050071', 'Exhaustion event', '20846');
+    });
+
+    it('quota - definitions and balances - reopening event', function() {
+      cy.quotaDefinitionsBalances('050086', 'Reopening event', '20852');
+    });
+
+    it('quota - definitions and balances - unblocking event', function() {
+      cy.quotaDefinitionsBalances('090007', 'Unblocking event', '1892');
+    });
+
+    it('quota - definitions and balances - unsuspension event', function() {
+      cy.quotaDefinitionsBalances('090204', 'Unsuspension event', '1691');
+    });
+  });
+
+  context('when on the XI service', function() {
+    const service = 'xi';
+
+    it('verify sections and chapter notes', function() {
+      cy.verifySectionChapterNotes(service);
+    });
+
+    it('verify search references', function() {
+      cy.verifySectionSearchReferences(service);
+    });
+
+    it('verify search references heading', function() {
+      cy.verifySearchReferencesHeading(service);
+    });
+
+    it('verify rollbacks', function() {
+      cy.verifyRollbacks(service);
+    });
+
+    it('CRUD a news item', function() {
+      cy.createNewsItem(service);
+      cy.verifyNewsItemOnTariffServices('Northern Ireland Online Tariff');
+      cy.verifyAndUpdateNewsItem(service);
+      cy.removeNewsItem(service);
+    });
+
+    it('verify tariff updates', function() {
+      cy.tariffUpdates(service);
+    });
+
+    it('reports', function() {
+      cy.reports(service);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -63,9 +63,12 @@
     "staging-tariff-frontend-smoketests": "CYPRESS_SPACE=STAGING CYPRESS_BASE_URL=https://staging.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/smokeTestCI.cy.js",
     "staging-tariff-backend-smoketests": "CYPRESS_SPACE=STAGING CYPRESS_BASE_URL=https://staging.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/smokeTestCI.cy.js",
     "staging-tariff-duty-calculator-smoketests": "CYPRESS_SPACE=STAGING CYPRESS_BASE_URL=https://staging.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/smokeTestCI.cy.js",
+    "staging-tariff-search-query-parser-smoketests": "CYPRESS_SPACE=STAGING CYPRESS_BASE_URL=https://staging.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/searchQueryParserSmokeTestsCI.cy.js",
+    "staging-tariff-admin-smoketests": "CYPRESS_SPACE=STAGING CYPRESS_BASE_URL=https://staging.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/adminSmokeTestCI.cy.js",
     "dev-tariff-frontend-smoketests": "CYPRESS_SPACE=DEVELOPMENT CYPRESS_BASE_URL=https://dev.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/devSmokeTestCI.cy.js",
     "dev-tariff-backend-smoketests": "CYPRESS_SPACE=DEVELOPMENT CYPRESS_BASE_URL=https://dev.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/devSmokeTestCI.cy.js",
     "dev-tariff-duty-calculator-smoketests": "CYPRESS_SPACE=DEVELOPMENT CYPRESS_BASE_URL=https://dev.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/dcSmokeTestCI.cy.js",
-    "dev-tariff-search-query-parser-smoketests": "CYPRESS_SPACE=DEVELOPMENT CYPRESS_BASE_URL=https://dev.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/searchQueryParserSmokeTestsCI.cy.js"
+    "dev-tariff-search-query-parser-smoketests": "CYPRESS_SPACE=DEVELOPMENT CYPRESS_BASE_URL=https://dev.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/searchQueryParserSmokeTestsCI.cy.js",
+    "dev-tariff-admin-smoketests": "CYPRESS_SPACE=DEVELOPMENT CYPRESS_BASE_URL=https://dev.trade-tariff.service.gov.uk yarn run cypress run --spec cypress/e2e/smoketests/cypress/e2e/smoketests/adminSmokeTestCI.cy.js"
   }
 }


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2264
https://github.com/trade-tariff/trade-tariff-frontend/pull/1322
https://github.com/trade-tariff/trade-tariff-admin/pull/402
https://github.com/trade-tariff/trade-tariff-search-query-parser/pull/134
https://github.com/trade-tariff/trade-tariff-duty-calculator/pull/598
https://github.com/trade-tariff/trade-tariff-backend/pull/1048


### What?

I have added/removed/altered:

- [x] Adds smoke tests for admin
- [x] Adds npm scripts for smoketests

### Why?

I am doing this because:

- This is required so that we integrate e2e with admin before we release to production
- The npm scripts were missing for staging in the search query parser (we hadn't enabled this on staging previously) and missing completely for the new admin smoketests
