### PR TITLE
HOTT-2376: Reflect admin string changes and make creating a news item more robust

### DIFF
--- a/cypress/e2e/AdminTool/adminTool-UK.cy.js
+++ b/cypress/e2e/AdminTool/adminTool-UK.cy.js
@@ -21,7 +21,7 @@ describe('UK - Admin tool regression tests', {tags: ['adminOnly']}, function() {
 
   it('CRUD a news item', function() {
     cy.createNewsItem('uk');
-    cy.verifyNewsItemOnTariffServices('UK Integrated Online Tariff');
+    cy.verifyNewsItemOnTariffServices();
     cy.verifyAndUpdateNewsItem('uk');
     cy.removeNewsItem('uk');
   });

--- a/cypress/e2e/AdminTool/adminTool-XI.cy.js
+++ b/cypress/e2e/AdminTool/adminTool-XI.cy.js
@@ -21,7 +21,7 @@ describe('XI - Admin tool regression tests', {tags: ['adminOnly']}, function() {
 
   it('CRUD a news item', function() {
     cy.createNewsItem('xi');
-    cy.verifyNewsItemOnTariffServices('Northern Ireland Online Tariff');
+    cy.verifyNewsItemOnTariffServices();
     cy.verifyAndUpdateNewsItem('xi');
     cy.removeNewsItem('xi');
   });

--- a/cypress/e2e/smoketests/adminSmokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/adminSmokeTestCI.cy.js
@@ -24,7 +24,7 @@ describe('Admin tool smoke tests', {tags: ['adminOnly']}, function() {
 
     it('CRUD a news item', function() {
       cy.createNewsItem(service);
-      cy.verifyNewsItemOnTariffServices('UK Integrated Online Tariff');
+      cy.verifyNewsItemOnTariffServices();
       cy.verifyAndUpdateNewsItem(service);
       cy.removeNewsItem(service);
     });
@@ -79,7 +79,7 @@ describe('Admin tool smoke tests', {tags: ['adminOnly']}, function() {
 
     it('CRUD a news item', function() {
       cy.createNewsItem(service);
-      cy.verifyNewsItemOnTariffServices('Northern Ireland Online Tariff');
+      cy.verifyNewsItemOnTariffServices();
       cy.verifyAndUpdateNewsItem(service);
       cy.removeNewsItem(service);
     });

--- a/cypress/support/adminCommands.js
+++ b/cypress/support/adminCommands.js
@@ -60,34 +60,26 @@ Cypress.Commands.add('verifySectionSearchReferences', (service) => {
   cy.get('.govuk-breadcrumbs').contains('Sections');
   cy.get('.govuk-breadcrumbs').contains('Section II');
   cy.contains('Search references of section II: Vegetable products');
-  cy.contains('Import and Export search references');
-  cy.contains('Import multiple search references from a CSV file');
-  cy.contains('Import search references CSV');
-  cy.contains('Export all search references as a CSV file');
-  cy.contains('Export all search references as CSV');
   cy.contains('Edit').click();
-  cy.contains('Search reference for Chapter (06)');
+  cy.contains('Search references for Chapter (06)');
   cy.url().should('include', '/search_references/chapters/06/search_references');
-  cy.contains('New Search reference').click();
+  cy.contains('Create new search reference').click();
   cy.url().should('include', '/search_references/chapters/06/search_references/new');
   cy.contains('New Search reference');
-  cy.contains('Search Reference');
-  cy.contains('Create Search reference');
   cy.contains('Back');
 });
 
 Cypress.Commands.add('verifySearchReferencesHeading', (service) => {
   cy.visit(`${adminUrl}/${service}/search_references/sections`);
   cy.verifyService(service);
-  cy.contains('Search references');
   cy.get('#section_4').contains('Prepared foodstuffs; beverages, spirits and vinegar; tobacco and manufactured tobacco substitutes');
   cy.get('#section_4 td a').click();
   cy.get('#chapter_20').contains('Preparations Of Vegetables, Fruit, Nuts Or Other Parts Of Plants');
   cy.get('#chapter_20').contains('1 to 9').click();
   cy.get('#heading_2008').contains('Fruit, Nuts And Other Edible Parts Of Plants');
   cy.get('#heading_2008').contains('Edit').click();
-  cy.contains('Search references Heading (2008)');
-  cy.contains('New Search reference');
+  cy.contains('Search references for Heading (2008)');
+  cy.contains('Create new search reference');
   cy.get('#main-content > div.govuk-auto-classes > table').contains('Title');
   cy.get('#main-content > div.govuk-auto-classes > table').contains('Actions');
 });
@@ -95,6 +87,7 @@ Cypress.Commands.add('verifySearchReferencesHeading', (service) => {
 Cypress.Commands.add('createNewsItem', (service) => {
   cy.visit(`${adminUrl}/${service}/news_items`);
   cy.contains('News stories');
+  cy.removeNewsItemIfExists('Automated Test');
   cy.contains('Add News story').click();
   cy.contains('New News story');
   cy.get('#news-item-title-field').type('Automated Test - Sample News Story');
@@ -128,10 +121,9 @@ Cypress.Commands.add('createNewsItem', (service) => {
   cy.contains('News item created');
 });
 
-Cypress.Commands.add('verifyNewsItemOnTariffServices', (tariffServiceHeading) => {
+Cypress.Commands.add('verifyNewsItemOnTariffServices', () => {
   cy.visit('/news');
   cy.get('.govuk-breadcrumbs__list').contains('News bulletin');
-  cy.contains(tariffServiceHeading);
   cy.contains('Automated Test - Sample News Story');
 });
 
@@ -255,3 +247,16 @@ Cypress.Commands.add('verifyService', (service) => {
   cy.get('.current-service').contains(`You are currently using the ${service.toUpperCase()} service`);
 });
 
+
+Cypress.Commands.add('removeNewsItemIfExists', (matchingText) => {
+  cy.get('table').find('tr').each(($row) => {
+    // Find the text in the row
+    if ($row.text().includes(matchingText)) {
+      // Find the Edit link within the row and click it
+      cy.wrap($row).find('a:contains("Edit")').click();
+      // On the next page, find the Remove link and click it along with the confirm popup
+      cy.get('a:contains("Remove")').click();
+      cy.on('window:confirm', () => true);
+    }
+  });
+});


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2376
https://github.com/trade-tariff/trade-tariff-frontend/pull/1330
https://github.com/trade-tariff/trade-tariff-admin/pull/408
https://github.com/trade-tariff/trade-tariff-admin/pull/411

### What?

I have added/removed/altered:

- [x] Added command to remove a news item if it exists
- [x] Updated existing news item tests to remove brittle static string verifications, reflect changes in news item pages

### Why?

I am doing this because:

- Any failure currently in the creation of the news item just leaves all of the tests in a blocked state. Removing any matching before proceeding should make this more robust.
