### PR TITLE
HOTT-2375: Adjusts the heading search references title

### DIFF
--- a/cypress/support/adminCommands.js
+++ b/cypress/support/adminCommands.js
@@ -78,7 +78,7 @@ Cypress.Commands.add('verifySearchReferencesHeading', (service) => {
   cy.get('#chapter_20').contains('1 to 9').click();
   cy.get('#heading_2008').contains('Fruit, Nuts And Other Edible Parts Of Plants');
   cy.get('#heading_2008').contains('Edit').click();
-  cy.contains('Search references for Heading (2008)');
+  cy.contains('Search references for heading 2008: Fruit, nuts');
   cy.contains('Create new search reference');
   cy.get('#main-content > div.govuk-auto-classes > table').contains('Title');
   cy.get('#main-content > div.govuk-auto-classes > table').contains('Actions');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2375
https://github.com/trade-tariff/trade-tariff-admin/pull/412

### What?

I have added/removed/altered:

- [x] Altered the expectation for the title of the headings search references page

### Why?

I am doing this because:

- This is to keep the admin tests passing as part of a recent change to this page
