### PR TITLE
Fixes slack notification colour

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -12,8 +12,6 @@ jobs:
       CYPRESS_grepTags: "-devOnly+-smokeTest+-notProduction+-adminOnly"
     name: "🚦 Regression Tests - UK and XI"
     runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
     steps:
       - run: date
       - uses: actions/checkout@v2
@@ -62,7 +60,7 @@ jobs:
           SLACK_CHANNEL: "tariffs-regression"
           SLACK_USERNAME: "Production Regression"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_COLOR: ${{ job.status }}
+          SLACK_COLOR: ${{ steps.cypress.outcome }}
           SLACK_ICON_EMOJI: ":alphabet-yellow-p:"
           SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
           SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/production/${{ steps.date.outputs.date }}/

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -21,8 +21,6 @@ jobs:
       CYPRESS_grepTags: "devOnly adminOnly"
     name: "RegressionTests - Development"
     runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
     steps:
       - run: date
       - uses: actions/checkout@v2
@@ -68,6 +66,7 @@ jobs:
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%d-%m-%Y')"
+
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:
@@ -75,7 +74,7 @@ jobs:
           SLACK_USERNAME: "Development Regression"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":alphabet-yellow-s:"
-          SLACK_COLOR: ${{ job.status }}
+          SLACK_COLOR: ${{ steps.cypress.outcome }}
           SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
           SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/development/${{ steps.date.outputs.date }}/
 

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -21,8 +21,6 @@ jobs:
       CYPRESS_grepTags: "-devOnly+-smokeTest+-notStaging"
     name: "RegressionTests - Staging"
     runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
     steps:
       - run: date
       - uses: actions/checkout@v2
@@ -83,6 +81,6 @@ jobs:
           SLACK_USERNAME: "Staging Regression"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":alphabet-yellow-s:"
-          SLACK_COLOR: ${{ job.status }}
+          SLACK_COLOR: ${{ steps.cypress.outcome }}
           SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
           SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/staging/${{ steps.date.outputs.date }}/


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Fixed colours of slack notification in development workflow
- [x] Fixed colours of slack notification in staging workflow
- [x] Fixed colours of slack notification in production workflow

```golang
	color := ""
	switch os.Getenv(EnvSlackColor) {
	case "success":
		color = "good"
	case "cancelled":
		color = "#808080"
	case "failure":
		color = "danger"
	default:
		color = envOr(EnvSlackColor, "good")
	}
```
