### PR TITLE
add news story collections

### DIFF
--- a/cypress/e2e/AdminTool/adminTool-UK.cy.js
+++ b/cypress/e2e/AdminTool/adminTool-UK.cy.js
@@ -26,6 +26,14 @@ describe('UK - Admin tool regression tests', {tags: ['adminOnly']}, function() {
     cy.removeNewsItem('uk');
   });
 
+  it('Edit news story collections', function() {
+    cy.editNewsStoryCollections('uk');
+  });
+
+  it('Verify add news story collections', function() {
+    cy.verifyAddNewsStoryCollections('uk');
+  });
+
   it('verify tariff updates', function() {
     cy.tariffUpdates('uk');
   });

--- a/cypress/e2e/AdminTool/adminTool-XI.cy.js
+++ b/cypress/e2e/AdminTool/adminTool-XI.cy.js
@@ -26,6 +26,14 @@ describe('XI - Admin tool regression tests', {tags: ['adminOnly']}, function() {
     cy.removeNewsItem('xi');
   });
 
+  it('Edit news story collections', function() {
+    cy.editNewsStoryCollections('xi');
+  });
+
+  it('Verify add news story collections', function() {
+    cy.verifyAddNewsStoryCollections('xi');
+  });
+
   it('verify tariff updates', function() {
     cy.tariffUpdates('xi');
   });

--- a/cypress/support/adminCommands.js
+++ b/cypress/support/adminCommands.js
@@ -121,6 +121,44 @@ Cypress.Commands.add('createNewsItem', (service) => {
   cy.contains('News item created');
 });
 
+Cypress.Commands.add('editNewsStoryCollections', (service) => {
+  cy.visit(`${adminUrl}/${service}/news_items`);
+  cy.contains('Manage news stories');
+  cy.contains('manage news story collections').click();
+  cy.url().should('include', '/news_collections');
+  cy.contains('Manage news story collections');
+  cy.get('.govuk-button').contains('Add a news story collection');
+  cy.contains('Edit').click();
+  cy.url().should('include', '/news_collections/1/edit');
+  cy.contains('Edit a news story collection');
+  cy.get('#news-collection-name-field').should('have.value', 'Trade news');
+  cy.get('#news-collection-priority-field').should('have.value', '1');
+  cy.contains('Is this collection published?');
+  cy.get('#news-collection-published-true-field').check();
+  cy.get('.govuk-button').contains('Update Collection');
+  cy.get('.govuk-button.govuk-button--secondary').contains('Back');
+  cy.get('.govuk-breadcrumbs__link').contains('Back to news story collections');
+});
+
+Cypress.Commands.add('verifyAddNewsStoryCollections', (service) => {
+  cy.visit(`${adminUrl}/${service}/news_items`);
+  cy.contains('Manage news stories');
+  cy.contains('manage news story collections').click();
+  cy.url().should('include', '/news_collections');
+  cy.contains('Manage news story collections');
+  cy.get('.govuk-button').contains('Add a news story collection').click();
+  cy.contains('Add a news story collection');
+  cy.get('#news-collection-name-field').should('have.value', '');
+  cy.get('#news-collection-priority-field').should('have.value', '');
+  cy.get('#news-collection-description-field').should('have.value', '');
+  cy.contains('Is this collection published?');
+  cy.contains('Yes');
+  cy.contains('No');
+  cy.get('.govuk-button').contains('Create Collection');
+  cy.get('.govuk-button.govuk-button--secondary').contains('Back');
+  cy.get('.govuk-breadcrumbs__link').contains('Back to news story collections');
+});
+
 Cypress.Commands.add('verifyNewsItemOnTariffServices', () => {
   cy.visit('/news');
   cy.get('.govuk-breadcrumbs__list').contains('News bulletin');


### PR DESCRIPTION
### Jira link

HOTT-2305(https://transformuk.atlassian.net/browse/HOTT-2305)

### What?

I have added/removed/altered the following:

- Added new automated tests for news story collections.

### Why?

I am doing this because:

- To ensure that manage news story collection and add news story collection pages are working as expected