### PR TITLE
Handle github action outcomes based on cypress outcome

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -70,3 +70,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: reports
           directory: reports_repo
+
+      - name: Set build status based on Cypress outcome
+        if: steps.cypress.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -84,3 +84,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: reports
           directory: reports_repo
+
+      - name: Set build status based on Cypress outcome
+        if: steps.cypress.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -84,3 +84,7 @@ jobs:
           SLACK_COLOR: ${{ steps.cypress.outcome }}
           SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
           SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/staging/${{ steps.date.outputs.date }}/
+
+      - name: Set build status based on Cypress outcome
+        if: steps.cypress.outcome != 'success'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Github Actions Regression Production](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regression.yml/badge.svg?branch=main&event=schedule)](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regression.yml)
 [![Github Actions Regression Staging](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionStaging.yml/badge.svg?branch=main&event=schedule)](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionStaging.yml)
-[![Github Actions Regression Development](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionDevelopment.yml/badge.svg?branch=main&event=schedule)](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionStaging.yml)
+[![Github Actions Regression Development](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionDevelopment.yml/badge.svg?branch=main&event=schedule)](https://github.com/trade-tariff/trade-tariff-testing/actions/workflows/regressionDevelopment.yml)
 [![CircleCI Smoke Tests](https://circleci.com/gh/trade-tariff/trade-tariff-testing.svg?style=svg)](https://circleci.com/gh/trade-tariff/trade-tariff-testing.svg?style=svg)
 
 This repository is responsible for validating integrations between different applications in the Online Trade Tariff service


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added step to set the outcome based on the cypress suite result for development
- [x] Added step to set the outcome based on the cypress suite result for staging
- [x] Added step to set the outcome based on the cypress suite result for production

### Why?

I am doing this because:

- This helps with visibility of failing jobs
