### PR TITLE
Legacy search results for ham have changed

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -168,7 +168,7 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     // when we switch back
     cy.get('#enable-beta-search > a').click();
     // we see legacy search results
-    cy.get('.search-results').contains('Results matching ‘ham’');
+    cy.get('.search-results').contains('Other results containing the term ‘ham’');
     // on the /search url
     cy.url().should('include', '/search');
   });


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Fix regression failures

### Why?

- Amber accidentally deleted the development opensearch cluster which included the full history of search references since this index was first created. These have gone from development and so we're getting different results for search reference matches on `ham`
