### PR TITLE
HOTT-2813: Validate single and double quoted search

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -183,4 +183,13 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.url().should('include', '/search');
     cy.get('[id^="beta-search-results-"]');
   });
+
+  it('Supports single and double quoted search terms', function() {
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    cy.searchForCommodity('"cherry tomatoes"');
+    cy.url().should('include', '/commodities/0702000007');
+    cy.searchForCommodity('\'For the manufacture of starch\'');
+    cy.url().should('include', '/commodities/0701901000');
+  });
 });


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2813

### What?

I have added/removed/altered:

- [x] Added e2e tests for double and single quoted search results

### Why?

I am doing this because:

- This integrates multiple layers of the frontend, backend and search query parser and needs validating
