### PR TITLE
HOTT-3034: Validate chemical search

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -205,4 +205,25 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
 
     expect(end - start).to.be.lessThan(minimumTimeFrame);
   });
+
+  it('Supports chemical search on cus numbers', function() {
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    cy.searchForCommodity('0154438-3');
+    cy.url().should('include', '/commodities/0409000000');
+  });
+
+  it('Supports chemical search on cas numbers', function() {
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    cy.searchForCommodity('7440-15-5');
+    cy.url().should('include', '/commodities/8112419000');
+  });
+
+  it('Supports chemical search on chemical names', function() {
+    cy.visit('/find_commodity');
+    cy.visit('/search/toggle_beta_search');
+    cy.searchForCommodity('cerium alloy');
+    cy.url().should('include', '/commodities/8105200000');
+  });
 });


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3034

### What?

I have added/removed/altered:

- [x] Added e2e coverage of the chemical search functionality

### Why?

I am doing this because:

- This is required to prove that the integration between the frontend and the backend works on an ongoing basis
