### PR TITLE
HOTT-2936: Adds validation of chemicals tab

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -211,6 +211,8 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.visit('/search/toggle_beta_search');
     cy.searchForCommodity('0154438-3');
     cy.url().should('include', '/commodities/0409000000');
+    cy.get('#tab_chemicals').click();
+    cy.get('.chemical-substance-cell').eq(0).contains('mel powder');
   });
 
   it('Supports chemical search on cas numbers', function() {
@@ -218,6 +220,8 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.visit('/search/toggle_beta_search');
     cy.searchForCommodity('7440-15-5');
     cy.url().should('include', '/commodities/8112419000');
+    cy.get('#tab_chemicals').click();
+    cy.get('.chemical-substance-cell').eq(0).contains('rhenium, unwrought; powders');
   });
 
   it('Supports chemical search on chemical names', function() {
@@ -225,5 +229,7 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
     cy.visit('/search/toggle_beta_search');
     cy.searchForCommodity('cerium alloy');
     cy.url().should('include', '/commodities/8105200000');
+    cy.get('#tab_chemicals').click();
+    cy.get('.chemical-substance-cell').eq(0).contains('cerium alloy');
   });
 });


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2936

### What?

I have added/removed/altered:

- [x] Added check for searching by name for a chemical and showing the chemicals tab
- [x] Added check for searching by cus for a chemical and showing the chemicals tab
- [x] Added check for searching by cas for a chemical and showing the chemicals tab

### Why?

I am doing this because:

- This is required to validate the integration for the chemicals tab on declarable pages
