### PR TITLE
HOTT-3124: Verify simplified procedural code measures api

### DIFF
--- a/cypress/e2e/UK/API/V2/jsonapi_validations.cy.js
+++ b/cypress/e2e/UK/API/V2/jsonapi_validations.cy.js
@@ -235,4 +235,13 @@ describe('Api validations', function() {
       });
     });
   });
+  describe('Api response for /api/v2/simplified_procedural_code_measures', function() {
+    const path = '/api/v2/simplified_procedural_code_measures';
+
+    it('returns a valid jsonapi response', function() {
+      cy.request(path).then((response) => {
+        cy.validJsonAPIresponse(response);
+      });
+    });
+  });
 });

--- a/cypress/e2e/XI/API/V2/jsonapi_validations.cy.js
+++ b/cypress/e2e/XI/API/V2/jsonapi_validations.cy.js
@@ -235,4 +235,13 @@ describe('Api validations', function() {
       });
     });
   });
+  describe('Api response for /xi/api/v2/simplified_procedural_code_measures', function() {
+    const path = '/xi/api/v2/simplified_procedural_code_measures';
+
+    it('returns a valid jsonapi response', function() {
+      cy.request(path).then((response) => {
+        cy.validJsonAPIresponse(response);
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3124
https://transformuk.atlassian.net/browse/HOTT-3126

Extensive endpoint tests for this exist, here https://github.com/trade-tariff/trade-tariff-backend/blob/main/spec/requests/api/v2/simplified_procedural_code_measures_controller_spec.rb as well as a whole bunch of filter unit tests for the models and their interaction with the view

### What?

I have added/removed/altered:

- [x] Added api specs to verify that the simplified procedural code api is plumbed together

### Why?

I am doing this because:

- This helps indicate when there is an issue with this api
