### PR TITLE
HOTT-3228: Adds coverage for expanded supplementary units

### DIFF
--- a/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
+++ b/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
@@ -10,6 +10,11 @@ describe('commodity supplementary unit classifications', function() {
       cy.contains('(1000 items, retail price)');
     });
 
+    it('shows the correct duty units classification', function() {
+      cy.visit('/uk/commodities/0402109900');
+      cy.contains('(hectokilogram, kilogram of lactic matter)');
+    });
+
     it('shows the correct no units classification', function() {
       cy.visit('/uk/commodities/6406109010');
       cy.contains('There are no supplementary unit measures');
@@ -22,13 +27,18 @@ describe('commodity supplementary unit classifications', function() {
       cy.contains('Number of pairs (pa)');
     });
 
+    it('shows the correct duty units classification', function() {
+      cy.visit('/xi/commodities/0402109900');
+      cy.contains('(hectokilogram, kilogram of lactic matter)');
+    });
+
     it('shows the correct excise units classification', function() {
-      cy.visit('/uk/commodities/2402900000');
+      cy.visit('/xi/commodities/2402900000');
       cy.contains('(1000 items, retail price)');
     });
 
     it('shows the correct no units classification', function() {
-      cy.visit('/uk/commodities/6406109010');
+      cy.visit('/xi/commodities/6406109010');
       cy.contains('There are no supplementary unit measures');
     });
   });


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3228
https://github.com/trade-tariff/trade-tariff-frontend/pull/1457

### What?

I have added/removed/altered:

- [x] Added coverage for extended supplementary units on UK and XI service

### Why?

I am doing this because:

- This is required to give better feedback to traders about the units they may need to declare
