### PR TITLE
HOTT-3228: Remove supplementary units without qualifier

### DIFF
--- a/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
+++ b/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
@@ -12,7 +12,7 @@ describe('commodity supplementary unit classifications', function() {
 
     it('shows the correct duty units classification', function() {
       cy.visit('/uk/commodities/0402109900');
-      cy.contains('(hectokilogram, kilogram of lactic matter)');
+      cy.contains('(kilogram of lactic matter)');
     });
 
     it('shows the correct no units classification', function() {
@@ -29,7 +29,7 @@ describe('commodity supplementary unit classifications', function() {
 
     it('shows the correct duty units classification', function() {
       cy.visit('/xi/commodities/0402109900');
-      cy.contains('(hectokilogram, kilogram of lactic matter)');
+      cy.contains('(kilogram of lactic matter)');
     });
 
     it('shows the correct excise units classification', function() {


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3228
https://github.com/trade-tariff/trade-tariff-frontend/pull/1459
https://github.com/trade-tariff/trade-tariff-frontend/pull/1460

### What?

I have added/removed/altered:

- [x] Removed supplementary units without qualifier

### Why?

I am doing this because:

- This was missed from the story initially and noticed in review
