### PR TITLE
HOTT-3274: Verify handling of missing uk declarable in supplementary units

### DIFF
--- a/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
+++ b/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
@@ -41,5 +41,10 @@ describe('commodity supplementary unit classifications', function() {
       cy.visit('/xi/commodities/6406109010');
       cy.contains('There are no supplementary unit measures');
     });
+
+    it('shows the correct classification when the uk declarable is missing', function() {
+      cy.visit('/xi/commodities/9919000060');
+      cy.contains('There are no supplementary unit measures');
+    });
   });
 });


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3274
https://github.com/trade-tariff/trade-tariff-frontend/pull/1470

### What?

I have added/removed/altered:

- [x] Added verification of an edge case in handling missing uk declarables when pulling the xi declarable units

### Why?

I am doing this because:

- This will likely cover future failures to load the commodities page despite being targeted at supplementary units
