### PR TITLE
Use past date with known data

### DIFF
--- a/cypress/support/dutyCommands.js
+++ b/cypress/support/dutyCommands.js
@@ -31,7 +31,7 @@ Cypress.Commands.add('validDate', ()=>{
   cy.get('#steps_import_date_import_date_3i').type('31');
   cy.get('#steps_import_date_import_date_2i').click();
   cy.get('#steps_import_date_import_date_2i').clear();
-  cy.get('#steps_import_date_import_date_2i').type('12');
+  cy.get('#steps_import_date_import_date_2i').type('05');
   cy.get('#steps_import_date_import_date_1i').click();
   cy.get('#steps_import_date_import_date_1i').clear();
   cy.get('#steps_import_date_import_date_1i').type('2023');


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Set the date we test for to be the end of May 2023

### Why?

I am doing this because:

- Currently it is set to a far future date
- Data for this far future date is still evolving
- Specs frequently fail because the are code to rely on data liable to change in the future
- Using a past date should result in testing against a known set of data that is unlikely to change

