### PR TITLE
Cypress parallel run & updates git workflows with latest versions

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -12,58 +12,152 @@ jobs:
       CYPRESS_grepTags: "-devOnly+-smokeTest+-notProduction+-adminOnly"
     name: "🚦 Regression Tests - UK and XI"
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [0, 1, 2, 3]
+    outputs:
+      output1: ${{ steps.cypress-outcome.outputs.test-status }}
     steps:
       - run: date
-      - uses: actions/checkout@v2
-      - uses: cypress-io/github-action@v4
-        name: cypress
+
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Generate lists of specs
+        id: speclist
+        run: |
+          find cypress/e2e -type f -name '*.cy.js' > all_specs.txt
+          split -n l/4 -d -a 1 all_specs.txt spec_group_
+          echo "specfiles=$(paste -d, -s spec_group_${{ matrix.containers }})" >> $GITHUB_OUTPUT
+
+      - name: Run cypress tests with chrome
         id: cypress
+        uses: cypress-io/github-action@v5
         continue-on-error: true
         with:
+          spec: ${{ steps.speclist.outputs.specfiles }}
           quiet: true
           browser: chrome
-          headless: true
-          spec: "cypress/e2e/**/*.cy.js"
-      - uses: actions/upload-artifact@v2
+      
+      - name: Cypress test outcome
+        id: cypress-outcome
+        run: |
+          echo "test-status=${{ steps.cypress.outcome }}" >> $GITHUB_OUTPUT
+
+      - name: Upload E2E test reports
+        uses: actions/upload-artifact@v3
         with:
-          name: report
-          path: ./cypress/reports/mochawesome/
+          name: test-reports-${{ matrix.containers }}
+          path: ./cypress/reports/
+  
+  gen_report:
+    name: Generate test report
+    needs: cypress-run
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install dependencies
+        run: npm install --save-dev mochawesome mochawesome-merge mochawesome-report-generator
+
+      - name: Create reports directory
+        run: mkdir reports
+
+      - name: Download test-reports-0
+        uses: actions/download-artifact@v3
+        with:
+          name: test-reports-0
+          path: reports/0
+
+      - name: Download test-reports-1
+        uses: actions/download-artifact@v3
+        with:
+          name: test-reports-1
+          path: reports/1
+
+      - name: Download test-reports-2
+        uses: actions/download-artifact@v3
+        with:
+          name: test-reports-2
+          path: reports/2
+
+      - name: Download test-reports-3
+        uses: actions/download-artifact@v3
+        with:
+          name: test-reports-3
+          path: reports/3
+
+      - name: Move all reports into one directory
+        run: |
+          mkdir -p mochawesome-report
+          i=0
+          for file in $(find reports -type f -name mochawesome\*.json); do
+            filename=$(basename "$file" .json)-"$i".json
+            mv "$file" mochawesome-report/"$filename"
+            ls mochawesome-report
+            i=$((i + 1))
+          done
+
+      - name: Merge and generate reports
+        run: |
+          mkdir report
+          npx mochawesome-merge > report/index.json
+          npx marge --inline report/index.json -o report/
+
+      - name: Upload report
+        uses: actions/upload-artifact@v3
+        with:
+          name: E2E Test Reports
+          path: report/
+
       - name: Checkout reports repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: reports
           path: reports_repo
+
       - name: Copy report into reports repo
         run: |
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
           [ -e docs/production/$DATE ] && rm -rf docs/production/$DATE
-          cp -a ../cypress/reports/mochawesome  docs/production/$DATE
+          cp -a ../report/  docs/production/$DATE
           pushd docs/production/$DATE
           rm -rf assets
           rm -rf screenshots
           ln -s ../../assets/
           popd
           git add docs .
+
       - name: Commit todays report to reports branch
         run: |
           cd reports_repo
           git config --local user.email "tradetarrif+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -m "Production report for $(date +%d-%m-%Y)" -a
+        
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: reports
+          directory: reports_repo
+
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%d-%m-%Y')"
+
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: "tariffs-regression"
           SLACK_USERNAME: "Production Regression"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_COLOR: ${{ steps.cypress.outcome }}
-          SLACK_ICON_EMOJI: ":alphabet-yellow-p:"
-          SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
+          SLACK_ICON_EMOJI: ":alphabet-yellow-s:"
+          SLACK_COLOR: ${{ needs.cypress-run.outputs.output1 }}
+          SLACK_TITLE: Cypress finished with - ${{ needs.cypress-run.outputs.output1 }}
           SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/production/${{ steps.date.outputs.date }}/
+
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
@@ -72,5 +166,5 @@ jobs:
           directory: reports_repo
 
       - name: Set build status based on Cypress outcome
-        if: steps.cypress.outcome != 'success'
+        if: needs.cypress-run.outputs.output1 != 'success'
         run: exit 1

--- a/.github/workflows/regressionDevelopment.yml
+++ b/.github/workflows/regressionDevelopment.yml
@@ -21,25 +21,36 @@ jobs:
       CYPRESS_grepTags: "devOnly adminOnly"
     name: "RegressionTests - Development"
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
     steps:
       - run: date
-      - uses: actions/checkout@v2
-      - uses: cypress-io/github-action@v4
-        name: cypress
+
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Run cypress tests with chrome
+        uses: cypress-io/github-action@v5
         id: cypress
         continue-on-error: true
         with:
           spec: "cypress/e2e/**/*.cy.js"
           quiet: true
           browser: chrome
-          headless: true
-      - uses: actions/upload-artifact@v2
+
+      - uses: actions/upload-artifact@v3
         with:
           name: report
-          path: ./cypress/reports/mochawesome/
+          path: ./cypress/reports/
+
+      - name: Merge and generate reports
+        run: |
+          mkdir report
+          npx mochawesome-merge ./cypress/reports/*.json > report/index.json
+          npx marge --inline report/index.json -o report/
 
       - name: Checkout reports repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: reports
           path: reports_repo
@@ -49,19 +60,27 @@ jobs:
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
           [ -e docs/development/$DATE ] && rm -rf docs/development/$DATE
-          cp -a ../cypress/reports/mochawesome  docs/development/$DATE
+          cp -a ../report/  docs/development/$DATE
           pushd docs/development/$DATE
           rm -rf assets
           rm -rf screenshots
           ln -s ../../assets/
           popd
           git add docs .
+
       - name: Commit todays report to reports branch
         run: |
           cd reports_repo
           git config --local user.email "tradetarrif+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -m "Development report for $(date +%d-%m-%Y)" -a
+      
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: reports
+          directory: reports_repo
 
       - name: Get current date
         id: date

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -21,25 +21,106 @@ jobs:
       CYPRESS_grepTags: "-devOnly+-smokeTest+-notStaging"
     name: "RegressionTests - Staging"
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [0, 1, 2, 3]
+    outputs:
+      output1: ${{ steps.cypress-outcome.outputs.test-status }}
     steps:
       - run: date
-      - uses: actions/checkout@v2
-      - uses: cypress-io/github-action@v4
-        name: cypress
+
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Generate lists of specs
+        id: speclist
+        run: |
+          find cypress/e2e -type f -name '*.cy.js' > all_specs.txt
+          split -n l/4 -d -a 1 all_specs.txt spec_group_
+          echo "specfiles=$(paste -d, -s spec_group_${{ matrix.containers }})" >> $GITHUB_OUTPUT
+
+      - name: Run cypress tests with chrome
         id: cypress
+        uses: cypress-io/github-action@v5
         continue-on-error: true
         with:
-          spec: "cypress/e2e/**/*.cy.js"
+          spec: ${{ steps.speclist.outputs.specfiles }}
           quiet: true
           browser: chrome
-          headless: true
-      - uses: actions/upload-artifact@v2
+      
+      - name: Cypress test outcome
+        id: cypress-outcome
+        run: |
+          echo "test-status=${{ steps.cypress.outcome }}" >> $GITHUB_OUTPUT
+
+      - name: Upload E2E test reports
+        uses: actions/upload-artifact@v3
         with:
-          name: report
-          path: ./cypress/reports/mochawesome/
+          name: test-reports-${{ matrix.containers }}
+          path: ./cypress/reports/
+
+  gen_report:
+    name: Generate test report
+    needs: cypress-run
+    if: always()
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install dependencies
+        run: npm install --save-dev mochawesome mochawesome-merge mochawesome-report-generator
+
+      - name: Create reports directory
+        run: mkdir reports
+
+      - name: Download test-reports-0
+        uses: actions/download-artifact@v3
+        with:
+          name: test-reports-0
+          path: reports/0
+
+      - name: Download test-reports-1
+        uses: actions/download-artifact@v3
+        with:
+          name: test-reports-1
+          path: reports/1
+
+      - name: Download test-reports-2
+        uses: actions/download-artifact@v3
+        with:
+          name: test-reports-2
+          path: reports/2
+
+      - name: Download test-reports-3
+        uses: actions/download-artifact@v3
+        with:
+          name: test-reports-3
+          path: reports/3
+
+      - name: Move all reports into one directory
+        run: |
+          mkdir -p mochawesome-report
+          i=0
+          for file in $(find reports -type f -name mochawesome\*.json); do
+            filename=$(basename "$file" .json)-"$i".json
+            mv "$file" mochawesome-report/"$filename"
+            ls mochawesome-report
+            i=$((i + 1))
+          done
+
+      - name: Merge and generate reports
+        run: |
+          mkdir report
+          npx mochawesome-merge > report/index.json
+          npx marge --inline report/index.json -o report/
+
+      - name: Upload report
+        uses: actions/upload-artifact@v3
+        with:
+          name: E2E Test Reports
+          path: report/
 
       - name: Checkout reports repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: reports
           path: reports_repo
@@ -49,20 +130,21 @@ jobs:
           cd reports_repo
           DATE=$(date +%d-%m-%Y)
           [ -e docs/staging/$DATE ] && rm -rf docs/staging/$DATE
-          cp -a ../cypress/reports/mochawesome  docs/staging/$DATE
+          cp -a ../report/  docs/staging/$DATE
           pushd docs/staging/$DATE
           rm -rf assets
           rm -rf screenshots
           ln -s ../../assets/
           popd
           git add docs .
+
       - name: Commit todays report to reports branch
         run: |
           cd reports_repo
           git config --local user.email "tradetarrif+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -m "Staging report for $(date +%d-%m-%Y)" -a
-
+      
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
@@ -81,10 +163,10 @@ jobs:
           SLACK_USERNAME: "Staging Regression"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":alphabet-yellow-s:"
-          SLACK_COLOR: ${{ steps.cypress.outcome }}
-          SLACK_TITLE: Cypress finished with - ${{ steps.cypress.outcome }}
+          SLACK_COLOR: ${{ needs.cypress-run.outputs.output1 }}
+          SLACK_TITLE: Cypress finished with - ${{ needs.cypress-run.outputs.output1 }}
           SLACK_MESSAGE: https://trade-tariff.github.io/trade-tariff-testing/staging/${{ steps.date.outputs.date }}/
 
       - name: Set build status based on Cypress outcome
-        if: steps.cypress.outcome != 'success'
+        if: needs.cypress-run.outputs.output1 != 'success'
         run: exit 1


### PR DESCRIPTION
Jira link

- HOTT-<[2229](https://transformuk.atlassian.net/browse/HOTT-2229)>

What?
I have added/removed/altered the following:

- Updated workflows, cypress config file and spec files to run regression suites in parallel to reduce the total execution time.

Why?
I am doing this because:

- Regression suite execution usually takes more than 1 hour 30 minutes to complete as a result we have to wait until it completes if we want to run before the release.

- As per new workflow and config updates, we can run the regression suite within 30 minutes and proceed with the release eventually we are reducing the execution and also our waiting time to complete the release.