### PR TITLE
HOTT-3543: Remove small brewers relief messaging

### DIFF
--- a/cypress/e2e/DutyCalculator/dcShared/dcExciseCode.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcExciseCode.cy.js
@@ -20,9 +20,6 @@ describe('🛃 | dcExciseCode.spec.js | Validate excise code on duty calculator 
     cy.quantity({asv: '40', ltr: '45'});
     cy.contains('Which class of excise is applicable to your trade?');
     cy.contains('Excise duty applies to trade in this commodity code. Select which class of excise duty applies to your trade');
-    cy.contains('Please note that the work to calculate the');
-    cy.contains('Small Breweries\' Relief (SBR)');
-    cy.contains('is in development and will be available shortly.');
 
     cy.contains('For more information on excise duty classes, please see');
     cy.contains('UK Trade: excise, duties, reliefs, drawbacks and allowances (opens in new browser window)');

--- a/cypress/e2e/smoketests/dcSmokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/dcSmokeTestCI.cy.js
@@ -41,7 +41,7 @@ describe('Duty Calculator smoke tests', {tags: ['smokeTest']}, function() {
     cy.dutyPage();
     cy.contains(' VAT');
     cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - GSP – Least Developed Countries');
+    cy.contains('Option 2: Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
     cy.contains('Option 4: Suspension - goods for certain categories of ships');
     cy.contains('Option 3: Airworthiness tariff suspension');
   });
@@ -119,7 +119,6 @@ describe('Duty Calculator smoke tests', {tags: ['smokeTest']}, function() {
     cy.contains('Customs value');
     cy.contains('Import quantity');
     cy.get('div:nth-of-type(1) > .govuk-summary-list__value').contains('1701 14 10 00');
-    cy.get('div:nth-of-type(3) > .govuk-summary-list__value').contains('31 December 2023');
     cy.get('div:nth-of-type(4) > .govuk-summary-list__value').contains('Northern Ireland');
     cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('United Kingdom (excluding Northern Ireland)');
     cy.get('div:nth-of-type(6) > .govuk-summary-list__value').contains('Yes');


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3543
https://github.com/trade-tariff/trade-tariff-duty-calculator/pull/637

### What?

I have added/removed/altered:

- [x] Removes small brewers relief messaging
- [x] Fixes broken duty calculator smoke tests

### Why?

I am doing this because:

- This functionality has been removed from the Duty Calculator
