### PR TITLE
BAU: Fixes smoke tests

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -152,14 +152,9 @@ Cypress.Commands.add('contextSelector', () => {
   cy.get('.govuk-table__body').contains('Date of trade');
 });
 
-Cypress.Commands.add('waitForCommoditySearchResults', () => {
-  cy.get('ul#q__listbox li:not(.autocomplete__option--no-results)').should('be.visible');
-});
-
 Cypress.Commands.add('searchForCommodity', (searchString) => {
   cy.get('.js-commodity-picker-select:last').click();
   cy.get('.js-commodity-picker-select:last').type(searchString);
-  cy.waitForCommoditySearchResults();
   // We submit by clicking the first result
   cy.get('#q__option--0').click();
 });
@@ -167,14 +162,12 @@ Cypress.Commands.add('searchForCommodity', (searchString) => {
 Cypress.Commands.add('searchForCommodity2', (searchString) => {
   cy.get('.js-commodity-picker-select:last').click();
   cy.get('.js-commodity-picker-select:last').type(searchString);
-  cy.waitForCommoditySearchResults();
   return cy.get('input[name=\'new_search\']').click();
 });
 
 Cypress.Commands.add('searchWithSearchField', (searchString) => {
   cy.get('input#q').click();
   cy.get('input#q').type(searchString);
-  cy.waitForCommoditySearchResults();
   cy.get('input[name=\'new_search\']').click();
 });
 


### PR DESCRIPTION
### Jira link

BAU

### What?

When finding a commodity we would wait for the suggestion list to
no longer populate a no-results option class by using the pseudo class selector
:not(.autocomplete__option--no-results).

Search suggestions are lightning fast these days and intermittently
we'll never experience a situation where we'll even see the no-results
class.

We get the waiting functionality rolled into the standard cy.get('#q__option--0').click();
behaviour.

This will retry the get until a timeout is reached basically making the
waitForCommoditySearchResults command completely redundant.

I have added/removed/altered:

- [x] Removed an incorrect waitForCommoditySearchResults command

### Why?

I am doing this because:

- This was leading to smoketests failures when search suggestions are quick
