### PR TITLE
HOTT-3878: Resolves change in suspension measures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ executors: # This is totally crazy but it's the only way to configure the enviro
     environment:
       CYPRESS_BASE_URL: "https://staging.trade-tariff.service.gov.uk"
       CYPRESS_SPACE: "STAGING"
-      CYPRESS_grepTags: "--devOnly --prodOnly --productionOnly"
 jobs:
   linters:
     docker:

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB-quota-safeguard-exclusions.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB-quota-safeguard-exclusions.cy.js
@@ -12,13 +12,13 @@ describe('Non preferential quota options from Taiwan to UK', function() {
     cy.dutyPage();
 
     // Validates Third country duty option includes safeguard in calculation
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.get('table.govuk-table:nth-of-type(1)').should('contain', 'Additional duties (safeguard) (UK)'); // check label
     cy.get('table.govuk-table:nth-of-type(1) > tbody > tr:nth-of-type(4) > td:nth-of-type(3)').contains('500.00'); // check vat
     cy.get('table.govuk-table:nth-of-type(1) > tbody > tr:nth-of-type(5) > td:nth-of-type(3)').contains('1,000.00'); // check total
 
     // Validates non-preferential-quota total does not include safeguard in calculation
-    cy.contains('Option 3: Non-preferential quota');
+    cy.contains('Non-preferential quota');
     cy.get('table.govuk-table:nth-of-type(3)').should('not.contain', 'safeguard'); // check label
     cy.get('table.govuk-table:nth-of-type(3) > tbody > tr:nth-of-type(3) > td:nth-of-type(3)').contains('400.00'); // check vat
     cy.get('table.govuk-table:nth-of-type(3) > tbody > tr:nth-of-type(4) > td:nth-of-type(3)').contains('400.00'); // check total

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB201--e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB201--e2e.cy.js
@@ -45,8 +45,8 @@ describe('| RoW-GB201--e2e.spec |🍅 - 🇻🇳 Vietnam to 🇬🇧 GB  | 201-e
     cy.contains('8.00% * £1,000.00');
     cy.get('tr:nth-of-type(3) > td:nth-of-type(3)').contains('£0.00');
     cy.contains('Import duty calculation');
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Vietnam');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Vietnam');
     cy.dcRooLink({country: 'Vietnam'});
   });
 });

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB202--e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB202--e2e.cy.js
@@ -69,8 +69,8 @@ describe('| RoW-GB202--e2e.spec |🇹🇷 Turkey to  🇬🇧 GB | 202-e2e.spec 
     cy.contains('Duty Total');
 
     cy.contains('Import duty calculation');
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Turkey');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Turkey');
     cy.contains('Definitive countervailing duty (UK)');
     cy.dcRooLink({country: 'Turkey'});
   });

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB203-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB203-e2e.cy.js
@@ -50,7 +50,7 @@ describe('| RoW-GB203-e2e.spec |🍅 China to 🇬🇧 GB | ', function() {
     cy.contains('Duty Total');
     cy.get('tr:nth-of-type(4) > td:nth-of-type(3)').contains('£0.00');
     cy.contains('Import duty calculation');
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference');
   });
 });

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB204-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB204-e2e.cy.js
@@ -15,10 +15,10 @@ describe('| RoW-GB204-e2e.spec | 🇦🇫🇸Afghanistan to 🇬🇧 GB  |', fun
     cy.confirmPage();
     cy.dutyPage();
     cy.contains(' VAT');
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
-    cy.contains('Option 3: Airworthiness tariff suspension');
-    cy.contains('Option 4: Suspension - goods for certain categories of ships, boats and');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
+    cy.contains('Airworthiness tariff suspension');
+    cy.contains('Suspension - goods for certain categories of ships, boats and');
     cy.contains('other vessels and for drilling or production platforms');
   });
 
@@ -32,8 +32,8 @@ describe('| RoW-GB204-e2e.spec | 🇦🇫🇸Afghanistan to 🇬🇧 GB  |', fun
     cy.exciseCode('333');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
     cy.contains('Wine at least 8.5 but not exceeding 22%');
   });
 
@@ -47,8 +47,8 @@ describe('| RoW-GB204-e2e.spec | 🇦🇫🇸Afghanistan to 🇬🇧 GB  |', fun
     cy.exciseCode('333');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - European Union');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - European Union');
     cy.contains('Wine at least 8.5 but not exceeding 22%');
     cy.contains('Import quantity');
   });

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB205--e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB205--e2e.cy.js
@@ -19,10 +19,10 @@ describe('|*RoW-GB205--e2e.spec | 🇸🇬 Singapore to 🇬🇧 GB  |', functio
     cy.confirmPage();
 
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Singapore');
-    cy.contains('Option 3: Non-preferential quota 057713');
-    cy.contains('Option 4: Non-preferential tariff quota under end-use 054320');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Singapore');
+    cy.contains('Non-preferential quota 057713');
+    cy.contains('Non-preferential tariff quota under end-use 054320');
     cy.contains('£28.00');
   });
 });

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB206-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB206-e2e.cy.js
@@ -20,8 +20,8 @@ describe('| RoW-GB206-e2e.spec | additional codes |', function() {
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Suspension - goods for certain categories of ships, ');
+    cy.contains('Third-country duty');
+    cy.contains('Suspension - goods for certain categories of ships, ');
     cy.contains('boats and other vessels and for drilling or production platforms');
     cy.contains(`1516 20 98 21 (C999)`);
     cy.contains(`Import duty (C999)`);
@@ -61,9 +61,9 @@ describe('| RoW-GB206-e2e.spec | additional codes |', function() {
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Canada');
-    cy.contains('Option 3: Suspension - goods for certain categories of ships, ');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Canada');
+    cy.contains('Suspension - goods for certain categories of ships, ');
     cy.contains('boats and other vessels and for drilling or production platforms');
     cy.contains(`1516 20 98 21 (B999, B999)`);
     cy.contains(`Import duty (B999)`);

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB207-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB207-e2e.cy.js
@@ -10,8 +10,8 @@ describe('| RoW-GB207-e2e.spec | excise codes |', function() {
     cy.exciseCode('615');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Norway');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Norway');
     cy.contains('615 - Cigars');
     cy.contains('£792.33');
   });
@@ -41,11 +41,11 @@ describe('| RoW-GB207-e2e.spec | excise codes |', function() {
     cy.contains('C119');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('520 - Light oil: unrebated (unmarked) – other unrebated light oil');
-    cy.contains('Option 2: Tariff preference - Liechtenstein');
-    cy.contains('Option 3: Autonomous suspension under end-use');
-    cy.contains('Option 4: Airworthiness tariff suspension');
+    cy.contains('Tariff preference - Liechtenstein');
+    cy.contains('Autonomous suspension under end-use');
+    cy.contains('Airworthiness tariff suspension');
     cy.contains('£248.75');
     cy.contains('£200.75');
     // Case 2 - Change excise code with 0 % excise

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB208--e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB208--e2e.cy.js
@@ -16,11 +16,11 @@ describe('| RoW-GB208--e2e.spec | Special calculations - alcohol % + sugar % |',
     cy.contains('24.77 GBP / l alc. 100% - £1.00 / for each litre of pure alcohol, multiplied by the SPR discount');
     cy.contains('£1,660.68');
     // validate calculations - third country duty
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('0.50 GBP / % vol/hl + 2.60 GBP / hl');
     cy.contains('£2,274.42');
     // tariff preference rate for Singapore
-    cy.contains('Option 2: Tariff preference - Singapore');
+    cy.contains('Tariff preference - Singapore');
     cy.contains('0.10 GBP / % vol/hl + 0.80 GBP / hl');
     cy.contains('£2,212.50');
   });
@@ -38,7 +38,7 @@ describe('| RoW-GB208--e2e.spec | Special calculations - alcohol % + sugar % |',
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('0.50 GBP / % vol/hl + 2.60 GBP / hl');
     cy.contains('Spirits at least 3.5 but less than 8.5% & eligible for SPR');
     cy.contains('£1,660.68');
@@ -67,11 +67,11 @@ describe('| RoW-GB208--e2e.spec | Special calculations - alcohol % + sugar % |',
     cy.contains('80');
     cy.confirmPage();
     // validate calculations - third country duty
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('0.30 GBP / 100 kg/net/%sacchar.');
     cy.contains('£3,916.80');
     // tariff preference rate for Singapore
-    cy.contains('Option 2: Tariff preference - Vietnam');
+    cy.contains('Tariff preference - Vietnam');
     cy.contains('0.10 GBP / 100 kg/net/%sacchar.');
     cy.contains('£1,305.60');
   });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI303a-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI303a-e2e.cy.js
@@ -13,7 +13,7 @@ describe('RoW-NI303a', function() {
     cy.customsValue({monetary: '500.00', shipping: '100.00', cost: '250.00'});
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('£0.00');
   });
@@ -38,7 +38,7 @@ describe('RoW-NI303a', function() {
     cy.dutyPage();
     cy.contains('Third-country duty (EU)');
     cy.contains('7.60 % + 0.00 EUR / 100 kg');
-    cy.contains('Option 2: Tariff preference - Central America');
+    cy.contains('Tariff preference - Central America');
     cy.contains('£247.52');
   });
 });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI303c-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI303c-e2e.cy.js
@@ -11,7 +11,7 @@ describe('RoW-NI303c', function() {
     cy.quantity({kgm: '230.98'});
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('£0.00');
   });
 
@@ -32,7 +32,7 @@ describe('RoW-NI303c', function() {
     cy.vat('20');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Tariff preference (EU)');
   });
 });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304a-delta--e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304a-delta--e2e.cy.js
@@ -30,7 +30,7 @@ describe('| Row-NI304a--delta.spec.js | Turnover > £500k | Delta Route - not pr
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('UK import duties apply, as the difference between the UK third country duty and ');
     cy.contains('the EU third country duty is lower than 3% of the customs value of your trade.');
@@ -65,11 +65,11 @@ describe('| Row-NI304a--delta.spec.js | Turnover > £500k | Delta Route - not pr
       cy.confirmPage();
       cy.dutyPage();
 
-      cy.contains('Option 1: Third-country duty');
+      cy.contains('Third-country duty');
       cy.contains('Third-country duty (UK)');
       cy.contains('UK import duties apply, as the difference between the UK third country duty and ');
       cy.contains('the EU third country duty is lower than 3% of the customs value of your trade.');
-      cy.contains('Option 2: Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
+      cy.contains('Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
     }
   });
   // Ad Valorem - delta mfn 3%
@@ -105,11 +105,11 @@ describe('| Row-NI304a--delta.spec.js | Turnover > £500k | Delta Route - not pr
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Developing Countries Trading Scheme (DCTS) - Enhanced Preferences');
-    cy.contains('Option 3: Suspension - goods for certain categories of ships, boats and other vessels and ');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Developing Countries Trading Scheme (DCTS) - Enhanced Preferences');
+    cy.contains('Suspension - goods for certain categories of ships, boats and other vessels and ');
     cy.contains('for drilling or production platforms');
-    cy.contains('Option 4: Airworthiness tariff suspension');
+    cy.contains('Airworthiness tariff suspension');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty and ');
     cy.contains('the EU third country duty exceeds 3% of the customs value of your trade.');
@@ -141,7 +141,7 @@ describe('| Row-NI304a--delta.spec.js | Turnover > £500k | Delta Route - not pr
     cy.dutyPage();
 
     cy.contains('Third-country duty will apply as there is no preferential agreement in place for the import of this commodity.');
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty and ');
     cy.contains('the EU third country duty exceeds 3% of the customs value of your trade.');

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304b-delta-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304b-delta-e2e.cy.js
@@ -52,7 +52,7 @@ describe('| Row-NI304b-delta.spec.js | >£500,000 | 🔼 Delta Route - undergo c
     // VAT Page
     cy.vat('20');
     cy.confirmPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('UK import duties apply, as the difference between the UK third country duty and the EU third country duty is lower than 3% of the customs value of your trade.');
   });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304c-delta-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304c-delta-e2e.cy.js
@@ -35,7 +35,7 @@ describe('| Row-NI304c-delta.spec.js |turnover > £500,000 |  🔼 Delta Route -
     cy.confirmPage();
     cy.contains('6307 90 92 00 (2600)');
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty and the EU third country duty exceeds 3% of the customs value of your trade.');
     cy.contains('Airworthiness tariff suspension (UK)');
@@ -70,15 +70,15 @@ describe('| Row-NI304c-delta.spec.js |turnover > £500,000 |  🔼 Delta Route -
     cy.confirmPage();
     cy.contains('2906 11 00 00 (2501)');
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty and the EU third country duty exceeds 3% of the customs value of your trade.');
 
-    cy.contains('Option 2: Tariff preference - San Marino');
+    cy.contains('Tariff preference - San Marino');
     cy.contains('UK preferential duties may be applied, as the difference between the UK preferential duty and the EU preferential duty is lower than 3% of the customs value of your trade.');
     cy.contains('Tariff preference (UK)');
 
-    cy.contains('Option 3: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
+    cy.contains('Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
     cy.contains('Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms (UK)');
     cy.contains('UK suspensions may be applied, as the difference between the UK suspension duty and the EU suspension duty is lower than 3% of the customs value of your trade.');
 
@@ -93,15 +93,15 @@ describe('| Row-NI304c-delta.spec.js |turnover > £500,000 |  🔼 Delta Route -
     cy.confirmPage();
     cy.contains('2906 11 00 00 (2500)');
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('UK import duties apply, as the difference between the UK third country duty and the EU third country duty is lower than 3% of the customs value of your trade.');
 
-    cy.contains('Option 2: Tariff preference - San Marino');
+    cy.contains('Tariff preference - San Marino');
     cy.contains('UK preferential duties may be applied, as the difference between the UK preferential duty and the EU preferential duty is lower than 3% of the customs value of your trade.');
     cy.contains('Tariff preference (UK)');
 
-    cy.contains('Option 3: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
+    cy.contains('Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
     cy.contains('Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms (UK)');
     cy.contains('UK suspensions may be applied, as the difference between the UK suspension duty and the EU suspension duty is lower than 3% of the customs value of your trade.');
   });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304d-delta-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304d-delta-e2e.cy.js
@@ -32,7 +32,7 @@ describe('| Row-NI304d-delta.spec.js | | Turnover > £500,000 | 🔼 Delta Route
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty and the EU third country duty exceeds 3% of the customs value of your trade.');
   });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304e-delta-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304e-delta-e2e.cy.js
@@ -25,10 +25,10 @@ describe('| Row-NI304e-delta.spec.js | 🔼 Delta Route | preferential rates UK 
     cy.quantity({kgm: '10000'});
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty and the EU third country duty exceeds 3% of the customs value of your trade.');
-    cy.contains('Option 2: Tariff preference - Canada');
+    cy.contains('Tariff preference - Canada');
     cy.contains('Tariff preference (UK)');
     cy.contains('UK preferential duties may be applied, as the difference between the UK preferential duty and the EU preferential duty is lower than 3% of the customs value of your trade.');
     cy.dcRooLink({country: 'Canada'});
@@ -57,7 +57,7 @@ describe('| Row-NI304e-delta.spec.js | 🔼 Delta Route | preferential rates UK 
     cy.quantity({kgm: '100'});
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('UK import duties apply, as the difference between the UK third country duty and the EU third country duty is lower than 3% of the customs value of your trade.');
 
@@ -69,7 +69,7 @@ describe('| Row-NI304e-delta.spec.js | 🔼 Delta Route | preferential rates UK 
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty and the EU third country duty exceeds 3% of the customs value of your trade.');
   });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304f-delta-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304f-delta-e2e.cy.js
@@ -30,16 +30,16 @@ describe('| Row-NI304f-delta.spec.js | 🔼 Delta Route - Acceptable route 2️�
     cy.contains('Continue').click();
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('A ‘Third country’ duty is the tariff charged where there isn’t a trade agreement or a customs union available. It can also be referred to as the Most Favoured Nation (MFN) rate.');
 
-    cy.contains(' Option 2: Tariff preference - Peru');
+    cy.contains(' Tariff preference - Peru');
     cy.contains('Tariff preference (UK)');
     cy.contains('UK preferential duties may be applied, as the difference between the UK preferential duty and the EU preferential duty is lower than 3% of the customs value of your trade.');
 
 
-    cy.contains('Option 3: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
+    cy.contains('Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
     cy.contains('Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms (UK)');
     cy.contains('UK suspensions may be applied, as the difference between the UK suspension duty and the EU suspension duty is lower than 3% of the customs value of your trade.');
   });
@@ -78,20 +78,20 @@ describe('| Row-NI304f-delta.spec.js | 🔼 Delta Route - Acceptable route 2️�
     cy.contains('C119, C990, N990');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('UK import duties apply, as the difference between the UK third country duty and the EU third country duty is lower than 3% of the customs value of your trade.');
 
-    cy.contains(' Option 2: Tariff preference - Andorra');
+    cy.contains(' Tariff preference - Andorra');
     cy.contains('Tariff preference (UK)');
     cy.contains('UK preferential duties may be applied, as the difference between the UK preferential duty and the EU preferential duty is lower than 3% of the customs value of your trade.');
 
-    cy.contains('Option 3: Autonomous tariff suspension');
+    cy.contains('Autonomous tariff suspension');
 
-    cy.contains('Option 5: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
+    cy.contains('Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
     cy.contains('UK suspensions may be applied, as the difference between the UK suspension duty and the EU suspension duty is lower than 3% of the customs value of your trade.');
 
-    cy.contains('Option 4: Airworthiness tariff suspension');
+    cy.contains('Airworthiness tariff suspension');
     cy.contains('UK suspensions may be applied, as the difference between the UK suspension duty and the EU suspension duty is lower than 3% of the customs value of your trade.');
   });
 });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304g-delta-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304g-delta-e2e.cy.js
@@ -38,12 +38,12 @@ describe('| Row-NI304g-delta.spec.js | 🔼 Delta Route | Quotas UK | ', functio
     cy.contains('Continue').click();
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('UK import duties apply, as the difference between the UK third country duty ');
     cy.contains('and the EU third country duty is lower than 3% of the customs value of your trade.');
     cy.contains('Tariff preference (UK)');
 
-    cy.contains('Option 2: Tariff preference - Canada');
+    cy.contains('Tariff preference - Canada');
     cy.contains('UK preferential duties may be applied, as the difference between the UK preferential duty ');
     cy.contains('and the EU preferential duty is lower than 3% of the customs value of your trade.');
   });
@@ -85,7 +85,7 @@ describe('| Row-NI304g-delta.spec.js | 🔼 Delta Route | Quotas UK | ', functio
 
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('UK import duties apply, as the difference between the UK third country duty ');
     cy.contains('and the EU third country duty is lower than 3% of the customs value of your trade.');
 
@@ -105,7 +105,7 @@ describe('| Row-NI304g-delta.spec.js | 🔼 Delta Route | Quotas UK | ', functio
     cy.contains('Continue').click();
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty ');
     cy.contains('and the EU third country duty exceeds 3% of the customs value of your trade.');

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304h-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304h-e2e.cy.js
@@ -28,7 +28,7 @@ describe('| Row-NI304h-delta.spec.js | Turnover < £500,000 | 🔼 Delta Route',
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('UK import duties apply');
   });
@@ -64,7 +64,7 @@ describe('| Row-NI304h-delta.spec.js | Turnover < £500,000 | 🔼 Delta Route',
     cy.contains('VAT');
     cy.contains('Standard rate');
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('UK import duties apply, as the difference between');
 
@@ -84,7 +84,7 @@ describe('| Row-NI304h-delta.spec.js | Turnover < £500,000 | 🔼 Delta Route',
     cy.contains('VAT');
     cy.contains('Standard rate');
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the');
     cy.contains('Suspension - goods for certain categories of ships');
@@ -124,7 +124,7 @@ describe('| Row-NI304h-delta.spec.js | Turnover < £500,000 | 🔼 Delta Route',
 
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('UK import duties apply, as the difference');
 
     cy.get('.govuk-back-link').click();
@@ -143,7 +143,7 @@ describe('| Row-NI304h-delta.spec.js | Turnover < £500,000 | 🔼 Delta Route',
 
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply');
   });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304i-delta-meursing--e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI304i-delta-meursing--e2e.cy.js
@@ -32,12 +32,12 @@ describe('| RoW-NI304i-delta-meursing--e2e.spec.js | 🔼 Delta Route with Meurs
     cy.vat('20');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('8.00% * £1,000.00');
     cy.contains('A ‘Third country’ duty is the tariff charged where there isn’t a trade agreement or a customs union available. It can also be referred to as the Most Favoured Nation (MFN) rate.');
     cy.contains('UK import duties apply, as the difference between the UK third country duty and the EU third country duty is lower than 3% of the customs value of your trade.');
-    cy.contains('Option 2: Tariff preference - Andorra');
+    cy.contains('Tariff preference - Andorra');
     cy.contains('Tariff preference (EU)');
     // change meursing code to 7049
 
@@ -51,10 +51,10 @@ describe('| RoW-NI304i-delta-meursing--e2e.spec.js | 🔼 Delta Route with Meurs
     cy.vat('20');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty and the EU third country duty exceeds 3% of the customs value of your trade.');
-    cy.contains('Option 2: Tariff preference - Andorra');
+    cy.contains('Tariff preference - Andorra');
     cy.contains('Tariff preference (EU)');
     cy.contains('9.00 % + EA MAX 24.20 % +ADSZ');
   });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI305-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI305-e2e.cy.js
@@ -11,7 +11,7 @@ describe('| RoW-NI305-e2e.spec |🚫 Trade Remedies - 🚫 0% MFN EU tariff - �
     cy.quantity({kgm: '23000.98'});
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
   });
 });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI306-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI306-e2e.cy.js
@@ -20,8 +20,8 @@ describe('| RoW-NI306-e2e.spec | 🚫 Trade Remedies - 🚫 0% MFN EU tariff - �
     cy.quantity({kgm: '230.98'});
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - OCTs (Overseas Countries and Territories)');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - OCTs (Overseas Countries and Territories)');
     cy.contains('Third-country duty (EU)');
     cy.contains('Tariff preference (EU)');
   });
@@ -47,7 +47,7 @@ describe('| RoW-NI306-e2e.spec | 🚫 Trade Remedies - 🚫 0% MFN EU tariff - �
     cy.contains('Continue').click();
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
 
     // change options
@@ -70,7 +70,7 @@ describe('| RoW-NI306-e2e.spec | 🚫 Trade Remedies - 🚫 0% MFN EU tariff - �
     cy.contains('Continue').click();
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
 
     // change options
@@ -95,7 +95,7 @@ describe('| RoW-NI306-e2e.spec | 🚫 Trade Remedies - 🚫 0% MFN EU tariff - �
     cy.contains('Continue').click();
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
   });
 });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI307-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI307-e2e.cy.js
@@ -1,91 +1,56 @@
-/* eslint-disable max-len */
-// 🚫 Trade Remedies - 🚫 0% MFN EU tariff - Trader Scheme - 🚫 UK Trader Scheme
-
-import dayjs from 'dayjs';
-
-const currentDate = dayjs().format('DD MMMM YYYY');
-
 describe('| RoW-NI307-e2e.spec | RoW (Argentina) to NI | Additional Codes + Document Codes |', function() {
-  //
   it('RoW 🇦🇷 Argentina to NI | add codes + doc codes |', function() {
     cy.visit('/duty-calculator/xi/1516209821/import-date');
-    // date
     cy.validDate();
-    // destination
     cy.selectDestination('xi');
-    // origin
-
-    // select country from list
-
     cy.otherOriginList({value: 'Argentina'});
-
-    // Duties Apply
     cy.euDutiesApply();
-    // customs value
     cy.customsValue({monetary: '500.00', shipping: '250.00', cost: '250.00'});
-    // Import Quantity
     cy.quantity({tnei: '1000'});
-    // Additional Codes
 
     cy.additionalCode({xi: 'C999'});
-    cy.additionalCode({xi: 'C496'});
-    // Document Codes
+    cy.additionalCode({xi: 'C999'});
     cy.docCode({xi: 'c990'});
     cy.contains('Continue').click();
-    // Document Codes
-    cy.docCode({xi: 'd017'});
-    cy.contains('Continue').click();
 
-    // VAT Page
     cy.vat('0');
     cy.contains('VAT zero rate');
     cy.contains('Additional code(s)');
-    cy.contains('C999, C496');
+    cy.contains('C999, C999');
     cy.contains('Document(s)');
-    cy.contains('C990, D017');
+    cy.contains('C990');
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains(`You are importing commodity 1516 20 98 21 (C999, C496) from Argentina on ${currentDate}.`);
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('10.90% * £1,000.00');
     cy.contains('172.20 EUR / 1000 kg/biodiesel');
-    cy.contains('Option 2: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms');
+    cy.contains('Suspension');
     cy.contains('0.00% * £1,000.00');
     cy.contains('172.20 EUR / 1000 kg/biodiesel');
-    // go back to previous page to change doc code
     cy.get('.govuk-back-link').click();
-    // Change to different Document Code
-    cy.get('div:nth-of-type(3) > .govuk-summary-list__actions > .govuk-link').click();
+    cy.get('a[href^="/duty-calculator/document-codes"]').contains('Change').click();
     cy.contains('Do you have any of the following documents?');
-    // Change doc codes and validate results reflected in calculations
-    // select none of the above Code
 
-    // Document Codes
     cy.docCode({xi: 'none'});
     cy.contains('Continue').click();
-    // Document Codes
-    cy.docCode({xi: 'none'});
-    cy.contains('Continue').click();
-    // VAT Page
     cy.vat('0');
     cy.contains('VAT zero rate');
     cy.contains('Additional code(s)');
-    cy.contains('C999, C496');
+    cy.contains('C999, C999');
     cy.contains('Document(s)');
     cy.contains('n/a');
     cy.confirmPage();
     cy.dutyPage();
 
-    cy.contains(`You are importing commodity 1516 20 98 21 (C999, C496) from Argentina on ${currentDate}.`);
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('10.90% * £1,000.00');
     cy.contains('Import duty (C999)');
     cy.contains('Definitive anti-dumping duty (EU)');
     cy.contains('172.20 EUR / 1000 kg/biodiesel');
-    cy.contains('Import duty (C496)');
+    cy.contains('Import duty (C999)');
     cy.contains('Definitive countervailing duty (EU)');
-    cy.contains('25.00% * £1,000.00');
-    cy.contains('Option 2: Suspension - goods for certain categories of ships, boats and other vessels and for drilling or production platforms').should('not.exist');
+    cy.contains('237.00 EUR / 1000 kg/biodiesel');
+    cy.contains('Suspension').should('not.exist');
   });
 });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI308-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI308-e2e.cy.js
@@ -40,10 +40,10 @@ describe('| RoW-NI308-e2e.spec | RoW (Norway) to NI | Document Code , Retail Pri
     cy.dutyPage();
     cy.contains(`You are importing commodity 2402 20 90 00 from Norway on ${currentDate}.`);
     // doc code y021 =  Apply the mentioned duty 27.95%
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('611 - Cigarettes');
 
-    cy.contains('Option 2: Tariff preference - European Economic Area');
+    cy.contains('Tariff preference - European Economic Area');
     cy.contains('27.95% * £1,000.00');
     cy.contains('Tariff preference (EU)');
 
@@ -68,8 +68,8 @@ describe('| RoW-NI308-e2e.spec | RoW (Norway) to NI | Document Code , Retail Pri
     cy.dutyPage();
     cy.contains(`You are importing commodity 2402 20 90 00 from Norway on ${currentDate}.`);
     // doc code No code  =  Measure not applicable
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('611 - Cigarettes');
-    cy.contains('Option 2: Tariff preference - European Economic Area').should('not.exist');
+    cy.contains('Tariff preference - European Economic Area').should('not.exist');
   });
 });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI309--e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/RoW-NI309--e2e.cy.js
@@ -16,9 +16,9 @@ describe('| RoW-NI309--e2e.spec | Special calculations - alcohol % + sugar % |',
     cy.confirmPage();
     cy.contains('Spirits at least 3.5 but less than 8.5% & eligible for SPR');
     cy.contains('£1,660.68');
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('0.50 GBP / % vol/hl + 2.60 GBP / hl');
-    cy.contains('Option 2: Tariff preference - Vietnam');
+    cy.contains('Tariff preference - Vietnam');
     cy.contains('0.20 GBP / % vol/hl + 1.30 GBP / hl');
   });
 
@@ -40,9 +40,9 @@ describe('| RoW-NI309--e2e.spec | Special calculations - alcohol % + sugar % |',
     cy.contains('% sucrose');
     cy.contains('80 ');
     cy.confirmPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('0.40 EUR / 100 kg/net/%sacchar.');
-    cy.contains('Option 2: Tariff preference - Viet Nam');
+    cy.contains('Tariff preference - Viet Nam');
     cy.contains('0.20 EUR / 100 kg/net/%sacchar.');
   });
 });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/Row-NI301-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/Row-NI301-e2e.cy.js
@@ -17,8 +17,8 @@ describe('| RoW-NI301-e2e.spec | RoW to Northern Ireland ', function() {
       cy.confirmPage();
       cy.dutyPage();
       cy.contains(' VAT');
-      cy.contains('Option 1: Third-country duty');
-      cy.contains('Option 2: Tariff preference - Israel');
+      cy.contains('Third-country duty');
+      cy.contains('Tariff preference - Israel');
       cy.contains('Tariff preference (UK)');
       cy.contains('£170.00');
     });

--- a/cypress/e2e/DutyCalculator/3.RoW-NI/Row-NI302-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/3.RoW-NI/Row-NI302-e2e.cy.js
@@ -19,7 +19,7 @@ describe('| RoW-NI302-e2e.spec | RoW to Northern Ireland ', function() {
 
       cy.confirmPage();
       cy.dutyPage();
-      cy.contains('Option 1: Third-country duty');
+      cy.contains('Third-country duty');
       cy.contains('4.70% * £1,000.00');
       cy.contains('£256.40');
     });

--- a/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI404-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI404-e2e.cy.js
@@ -45,11 +45,11 @@ describe('GB-NI404-e2e.spec|GB to NI route 04-Trade Remedies-0% MFN EU-Trader Sc
     cy.contains('2300.98');
     cy.get('.govuk-button').click();
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('Zero rate');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Claiming a waiver – Exchange rate');
   });
 
   it(`e2e GB to NI - Meursing Code `, function() {
@@ -89,11 +89,11 @@ describe('GB-NI404-e2e.spec|GB to NI route 04-Trade Remedies-0% MFN EU-Trader Sc
 
     cy.confirmPage();
 
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
 
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Claiming a waiver – Exchange rate');
   });
 });

--- a/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI406-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI406-e2e.cy.js
@@ -34,11 +34,11 @@ describe('GB-NI406-e2e.spec|EU Duties|GB to NI route06-Trade Remedies-0% MFN EU-
 
     cy.get('.govuk-button').click();
 
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
     cy.contains('Tariff preference (EU)');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Claiming a waiver – Exchange rate');
   });
 
   it('e2e GB to NI - Meursing Code GB-NI406', function() {
@@ -75,11 +75,11 @@ describe('GB-NI406-e2e.spec|EU Duties|GB to NI route06-Trade Remedies-0% MFN EU-
 
     cy.confirmPage();
 
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
 
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Claiming a waiver – Exchange rate');
   });
 });

--- a/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI408a-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI408a-e2e.cy.js
@@ -100,9 +100,9 @@ describe('GB-NI408a-e2e.spec|GB to NI route08-Trade Remedies-0% MFN EU tariff-Tr
 
     // Final Page
     cy.exchangeRate();
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Claiming a waiver – Exchange rate');
   });
 
   it('e2e GB to NI - Meursing code ', function() {
@@ -177,7 +177,7 @@ describe('GB-NI408a-e2e.spec|GB to NI route08-Trade Remedies-0% MFN EU tariff-Tr
     cy.vat('20');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('A tariff preference is the rate available if a free trade agreement or');
     cy.contains('another arrangement is in place between the UK and an overseas country.');

--- a/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI408b-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI408b-e2e.cy.js
@@ -64,9 +64,9 @@ describe('GB-NI408b-e2e.spec|GB to NI route08-Trade Remedies-0% MFN EU tariff-Tr
     cy.contains('33.90 EUR / 100 kg std qual');
 
     cy.contains('Duty Total');
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Claiming a waiver – Exchange rate');
     cy.exchangeRate();
   });
 });

--- a/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI409a-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI409a-e2e.cy.js
@@ -35,9 +35,9 @@ describe('| GB-NI409a-e2e.spec | GB to NI route 🚌 09 - ✅  Trade Remedies |'
     cy.get('div:nth-of-type(5) > .govuk-summary-list__value').contains('£5,785.87');
     cy.get('.govuk-button').click();
 
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Claiming a waiver – Exchange rate');
     cy.exchangeRate();
   });
 });

--- a/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI409b-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/4.GB-NI/GB-NI409b-e2e.cy.js
@@ -37,14 +37,14 @@ describe('| GB-NI409b-e2e.spec | GB to NI route 🚌 09 - ✅  Trade Remedies + 
 
 
     cy.contains('Import duty calculation');
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('A ‘Third country’ duty is the tariff charged where there isn’t a trade agreement or');
     cy.contains('a customs union available. It can also be referred to as the Most Favoured Nation (MFN) rate.');
-    cy.contains('Option 2: Tariff preference');
+    cy.contains('Tariff preference');
     cy.contains('A tariff preference is the rate available if a free trade agreement or another arrangement');
     cy.contains('is in place between the UK and an overseas country. Goods will need to comply with the rules of origin');
     cy.contains('to benefit from this rate and you will need to provide evidence of compliance with your shipment.');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Claiming a waiver – Exchange rate');
     cy.contains('A claim for a customs duty waiver for duty on goods');
     cy.contains('that would otherwise incur “at risk” tariffs is provided as “de minimis aid”.');
     cy.contains('The maximum allowance for most sectors is €200,000 across a rolling three tax year period.');

--- a/cypress/e2e/DutyCalculator/dcShared/dcAdditionalCode.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcAdditionalCode.cy.js
@@ -26,6 +26,6 @@ describe('| dcAdditionalCode | RoW to GB - additional codes |', {tags: ['config'
     cy.contains('You are importing commodity');
     cy.contains(`from Israel on ${currentDate}.`);
     cy.contains('6307 90 92 00 (2600)');
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
   });
 });

--- a/cypress/e2e/DutyCalculator/dcShared/dcDocumentCode.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcDocumentCode.cy.js
@@ -23,12 +23,9 @@ describe('validate document codes step and outcomes', function() {
     cy.get('.govuk-error-summary');
     cy.contains('There is a problem');
     cy.contains('Specify a valid option');
-    cy.get('.govuk-error-message')
-        .contains('Specify a valid option');
-    cy.get('.govuk-back-link').click();
+    cy.get('.govuk-error-message').contains('Specify a valid option');
 
     // when we pick a positive case for a document code which will filter in a suspension measure
-    cy.contains('Do you have any of the following documents?');
     cy.docCode({xi: 'c990'});
     cy.contains('Continue').click();
     cy.docCode({xi: 'd008'});
@@ -41,6 +38,7 @@ describe('validate document codes step and outcomes', function() {
     cy.contains('Document(s)');
     cy.contains('C990');
     cy.get('.govuk-button').click();
+
     // then we see the suspension measure as an option for our document codes
     cy.contains('Suspension - goods for certain categories of ships, ');
 

--- a/cypress/e2e/DutyCalculator/dcShared/dcDocumentCode.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcDocumentCode.cy.js
@@ -1,142 +1,67 @@
-describe('📄 | dcDocumentCode.spec.js | Validate Document codes on duty calculator |', function() {
-// Scenario - document code c990 is associated with 0% suspensions on XI and no document will lead to measure not applicable
-  it('Page Validation - RoW (Canada) - XI ', function() {
-    cy.visit('/duty-calculator/xi/1516209830/import-date');
+describe('validate document codes step and outcomes', function() {
+  it('works as expected', function() {
+    // given a commodity with document codes
+    cy.visit('/duty-calculator/xi/1516209821/import-date');
     cy.validDate();
     cy.selectDestination('xi');
     cy.selectOrigin('other');
-    // select country from list
 
     cy.otherOriginList({value: 'Canada'});
-    // EU duties apply
     cy.euDutiesApply();
-    // Monetary value page
     cy.customsValue({monetary: '500.00', shipping: '250.00', cost: '250.00'});
+    cy.quantity({tnei: '1'});
 
-    // Document Codes - Page validation
+    cy.additionalCode({xi: 'B107'});
+    cy.additionalCode({xi: 'B107'});
+
+    // when we try to continue without selecting any document codes
     cy.contains('Do you have any of the following documents?');
     cy.contains('You may be able to reduce the duty applicable if you possess and can present one of the following documents.');
     cy.contains('Continue').click();
 
-    // Error message when Document code NOT selected
+    // then we should see an error message
     cy.get('.govuk-error-summary');
     cy.contains('There is a problem');
     cy.contains('Specify a valid option');
     cy.get('.govuk-error-message')
         .contains('Specify a valid option');
     cy.get('.govuk-back-link').click();
-    cy.contains('Continue').click();
-    cy.docCode({xi: 'none'});
-    cy.contains('Continue').click();
-    cy.contains('Which VAT rate is applicable to your trade?');
-    cy.get('.govuk-back-link').click();
 
-    // Select Document Code
+    // when we pick a positive case for a document code which will filter in a suspension measure
     cy.contains('Do you have any of the following documents?');
     cy.docCode({xi: 'c990'});
     cy.contains('Continue').click();
+    cy.docCode({xi: 'd008'});
+    cy.contains('Continue').click();
+    cy.docCode({xi: 'd008'});
+    cy.contains('Continue').click();
 
-    // VAT Page
     cy.vat('0');
     cy.contains('VAT zero rate');
     cy.contains('Document(s)');
     cy.contains('C990');
     cy.get('.govuk-button').click();
-    // Validate calculations based on document code selected
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Canada');
-    cy.contains('Option 3: Suspension - goods for certain categories of ships, ');
-    cy.contains('boats and other vessels and for drilling or production platforms');
-    cy.contains('Suspension - goods for certain categories of ships, boats ');
-    cy.contains('and other vessels and for drilling or production platforms (EU)');
+    // then we see the suspension measure as an option for our document codes
+    cy.contains('Suspension - goods for certain categories of ships, ');
 
-    // go back to previous page to change doc code
+    // when we pick the negative case for a document code
     cy.get('.govuk-back-link').click();
-    // Change to different Document Code
-    cy.get('div:nth-of-type(2) > .govuk-summary-list__actions > .govuk-link').click();
+    cy.get('a[href^="/duty-calculator/document-codes"]').contains('Change').click();
     cy.contains('Do you have any of the following documents?');
-    // select none of the above Code
     cy.docCode({xi: 'none'});
     cy.contains('Continue').click();
-    // VAT Page
+    cy.docCode({xi: 'none'});
+    cy.contains('Continue').click();
+    cy.docCode({xi: 'none'});
+    cy.contains('Continue').click();
     cy.vat('0');
     cy.contains('VAT zero rate');
     cy.get('.govuk-grid-row').contains('Document(s)');
     cy.contains('n/a');
     cy.get('.govuk-grid-row').contains('C990').should('not.exist');
     cy.get('.govuk-button').click();
-    // Validate calculations based on document code selected
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Canada');
-  });
-  // RoW-XI more than one doc code ( Norway)
-  it('multiple doc codes Norway ', function() {
-    cy.visit('/duty-calculator/xi/1905320500/import-date');
-    cy.validDate();
-    cy.selectDestination('xi');
-    cy.selectOrigin('other');
-    // select country from list
 
-    cy.otherOriginList({value: 'Norway'});
-    // Trader Scheme
-    cy.traderScheme('no');
-    // EU duties apply
-    cy.euDutiesApply();
-    // meursing code
-    cy.meursingCode({value: '000'});
-    // // ✅  Final use in NI - Yes
-    // // turn over < 500k = no
-    // customs value
-    // Monetary value page
-    cy.customsValue({monetary: '500.00', shipping: '250.00', cost: '250.00'});
-    // Import Quantity
-    cy.quantity({kgm: '230.98'});
-    cy.docCode({xi: 'y021'});
-    cy.contains('Continue').click();
-    // VAT Page
-    cy.vat('0');
-    cy.contains('VAT zero rate');
-    cy.contains('Document(s)');
-    cy.contains('Y021');
-    cy.get('.govuk-button').click();
-    // Validate calculations based on document code selected
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - European Economic Area');
-    cy.contains('Option 3: Tariff preference - Norway');
-
-    // go back to previous page to change doc code
-    cy.get('.govuk-back-link').click();
-    // Change to different Document Code
-    cy.get('div:nth-of-type(2) > .govuk-summary-list__actions > .govuk-link').click();
-    cy.contains('Do you have any of the following documents?');
-    cy.docCode({xi: 'y020'});
-    cy.contains('Continue').click();
-    // VAT Page
-    cy.vat('0');
-    cy.contains('VAT zero rate');
-    cy.contains('Document(s)');
-    cy.contains('Y020');
-    cy.get('.govuk-button').click();
-    // Validate calculations based on document code selected
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - European Economic Area');
-    cy.contains('Option 3: Tariff preference - Norway');
-    // select none of the above Code
-    // go back to previous page to change doc code
-    cy.get('.govuk-back-link').click();
-    // Change to different Document Code
-    cy.get('div:nth-of-type(2) > .govuk-summary-list__actions > .govuk-link').click();
-    cy.contains('Do you have any of the following documents?');
-    cy.docCode({xi: 'none'});
-    cy.contains('Continue').click();
-    // VAT Page
-    cy.vat('0');
-    cy.contains('VAT zero rate');
-    cy.get('.govuk-grid-row').contains('Document(s)');
-    cy.contains('n/a');
-    cy.get('.govuk-grid-row').contains('C990').should('not.exist');
-    cy.get('.govuk-button').click();
-    // Validate calculations based on document code selected
-    cy.contains('Option 1: Third-country duty');
+    // then we do not see a suspension measure as an option for our document code
+    cy.should('not.contain', 'Suspension');
   });
 });

--- a/cypress/e2e/DutyCalculator/dcShared/dcDutyPage.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcDutyPage.cy.js
@@ -77,8 +77,8 @@ describe('🧮 | dcDutyPage | Duties Calculated - page |', function() {
     cy.contains('A ‘Third country’ duty is the tariff charged where there isn’t a trade agreement or a customs union available.');
     cy.contains('It can also be referred to as the Most Favoured Nation (MFN) rate.');
 
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Claiming a waiver – Exchange rate');
   });
 });

--- a/cypress/e2e/DutyCalculator/dcShared/dcExciseCode.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcExciseCode.cy.js
@@ -78,11 +78,11 @@ describe('🛃 | dcExciseCode.spec.js | Validate excise code on duty calculator 
     cy.confirmPage();
 
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('520 - Light oil: unrebated (unmarked) – other unrebated light oil');
-    cy.contains('Option 2: Tariff preference - European Economic Area');
-    cy.contains('Option 3: Autonomous suspension under end-use');
-    cy.contains('Option 4: Airworthiness tariff suspension');
+    cy.contains('Tariff preference - European Economic Area');
+    cy.contains('Autonomous suspension under end-use');
+    cy.contains('Airworthiness tariff suspension');
 
     cy.get('.govuk-back-link').click();
     cy.get('div:nth-of-type(12) > .govuk-summary-list__actions > .govuk-link').click();

--- a/cypress/e2e/DutyCalculator/dcShared/dcVAT-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcVAT-e2e.cy.js
@@ -170,8 +170,8 @@ describe('| 🛄 dcVAT-e2e | VAT final page calculations |', function() {
     cy.contains('Reduced rate');
 
     // Final Page
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Claiming a waiver – Exchange rate');
   });
 });

--- a/cypress/e2e/smoketests/dcSmokeTest-Mobile-UK.cy.js
+++ b/cypress/e2e/smoketests/dcSmokeTest-Mobile-UK.cy.js
@@ -57,7 +57,7 @@ describe('Duty Calculator mobile smoke tests', {tags: ['smokeTest']}, function()
       cy.get('.govuk-button').click();
       cy.mobileMenu();
       // Final Page
-      cy.contains('Option 1: Third-country duty');
+      cy.contains('Third-country duty');
     });
   }
   // XI e2e test on iphone and samsung
@@ -106,7 +106,7 @@ describe('Duty Calculator mobile smoke tests', {tags: ['smokeTest']}, function()
       cy.mobileMenu();
       cy.dutyPage();
       cy.mobileMenu();
-      cy.contains('Option 1: Third-country duty');
+      cy.contains('Third-country duty');
       cy.mobileMenu();
     });
   }

--- a/cypress/e2e/smoketests/dcSmokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/dcSmokeTestCI.cy.js
@@ -40,10 +40,10 @@ describe('Duty Calculator smoke tests', {tags: ['smokeTest']}, function() {
     cy.confirmPage();
     cy.dutyPage();
     cy.contains(' VAT');
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
-    cy.contains('Option 4: Suspension - goods for certain categories of ships');
-    cy.contains('Option 3: Airworthiness tariff suspension');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
+    cy.contains('Suspension - goods for certain categories of ships');
+    cy.contains('Airworthiness tariff suspension');
   });
 
   it('🚀 XI 🇪🇺 - Duty Calculator e2e - RoW 🇦🇩 (Andorra) - XI 304i | Meursing code 7000', function() {
@@ -62,13 +62,13 @@ describe('Duty Calculator smoke tests', {tags: ['smokeTest']}, function() {
     cy.vat('20');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (UK)');
     cy.contains('8.00% * £1,000.00');
     cy.contains('A ‘Third country’ duty is the tariff charged');
 
     cy.contains('UK import duties apply, as the difference between the UK third country duty');
-    cy.contains('Option 2: Tariff preference - Andorra');
+    cy.contains('Tariff preference - Andorra');
     cy.contains('Tariff preference (EU)');
 
     cy.get('.govuk-back-link').click();
@@ -80,10 +80,10 @@ describe('Duty Calculator smoke tests', {tags: ['smokeTest']}, function() {
     cy.vat('20');
     cy.confirmPage();
     cy.dutyPage();
-    cy.contains('Option 1: Third-country duty');
+    cy.contains('Third-country duty');
     cy.contains('Third-country duty (EU)');
     cy.contains('EU import duties apply, as the difference between the UK third country duty');
-    cy.contains('Option 2: Tariff preference - Andorra');
+    cy.contains('Tariff preference - Andorra');
     cy.contains('Tariff preference (EU)');
     cy.contains('9.00 % + EA MAX 24.20 % +ADSZ');
   });
@@ -126,9 +126,9 @@ describe('Duty Calculator smoke tests', {tags: ['smokeTest']}, function() {
     cy.contains('23.98');
     cy.get('.govuk-button').click();
 
-    cy.contains('Option 1: Third-country duty');
-    cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
-    cy.contains('Option 3: Claiming a waiver – Exchange rate');
+    cy.contains('Third-country duty');
+    cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
+    cy.contains('Claiming a waiver – Exchange rate');
   });
 
   it('🚀 XI 🇪🇺 - Duty Calculator e2e - ( EU to NI )', function() {

--- a/cypress/e2e/smoketests/smokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/smokeTestCI.cy.js
@@ -241,8 +241,8 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.confirmPage();
       cy.dutyPage();
 
-      cy.contains('Option 1: Third-country duty');
-      cy.contains('Option 2: Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
+      cy.contains('Third-country duty');
+      cy.contains('Tariff preference - Developing Countries Trading Scheme (DCTS) - Comprehensive Preferences');
     });
 
     it('RoW - Duty Calculator e2e - United Arab Emirates - XI', function() {
@@ -264,7 +264,7 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.confirmPage();
       cy.dutyPage();
 
-      cy.contains('Option 1: Third-country duty');
+      cy.contains('Third-country duty');
       cy.contains('Third-country duty (EU)');
       cy.contains('EU import duties apply, as the difference between the UK');
     });
@@ -426,10 +426,10 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.quantity({kgm: '10000'});
       cy.confirmPage();
       cy.dutyPage();
-      cy.contains('Option 1: Third-country duty');
+      cy.contains('Third-country duty');
       cy.contains('Third-country duty (EU)');
       cy.contains('EU import duties apply');
-      cy.contains('Option 2: Tariff preference - Canada');
+      cy.contains('Tariff preference - Canada');
       cy.contains('Tariff preference (UK)');
       cy.contains('UK preferential duties may be applied');
     });
@@ -461,12 +461,12 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.contains('Customs value');
       cy.contains('Import quantity');
       cy.confirmPage();
-      cy.contains('Option 1: Third-country duty');
-      cy.contains('Option 1: Third-country duty');
+      cy.contains('Third-country duty');
+      cy.contains('Third-country duty');
       cy.contains('Third-country duty (EU)');
-      cy.contains('Option 2: Tariff preference - United Kingdom (excluding Northern Ireland)');
+      cy.contains('Tariff preference - United Kingdom (excluding Northern Ireland)');
 
-      cy.contains('Option 3: Claiming a waiver – Exchange rate');
+      cy.contains('Claiming a waiver – Exchange rate');
     });
 
     it('Duty Calculator e2e - ( EU to NI ) EU-NI501', function() {

--- a/cypress/support/dutyCommands.js
+++ b/cypress/support/dutyCommands.js
@@ -271,7 +271,10 @@ Cypress.Commands.add('docCode', (dcode) => {
   cy.contains('Do you have any of the following documents?');
   cy.title().should('eq', 'Do you have any of the following documents - Online Tariff Duty Calculator');
   for (const [key, value] of Object.entries(dcode)) {
-    cy.get(`#steps-document-code-document-code-${key}-${value}-field.govuk-radios__input`).check();
+    cy.get(
+        `input[id="steps-document-code-document-code-${key}-${value}-field"], \
+         input[id="steps-document-code-document-code-${key}-field-error"]`,
+    ).check();
   }
 });
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3878

### What?

I have added/removed/altered:

- [x] Fixes tests of duty calculator which depend on suspension measures that have changed
- [x] Transition to less brittle option positions

### Why?

I am doing this because:

- These are blocking us from deploying to production
- If the order of the measures changes this will break the tests. We're not interested in having failures for these kind of scenarios
