### PR TITLE
BAU: Use an unchanging 10-digit subheading for search

### DIFF
--- a/cypress/e2e/legacySearch.cy.js
+++ b/cypress/e2e/legacySearch.cy.js
@@ -141,8 +141,8 @@ describe('Legacy search', function() {
     });
 
     it('search navigates to 10 digit subheadings', function() {
-      cy.get('#q').type('2007993929{enter}');
-      cy.url().should('match', /\/subheadings\/2007993929-(10|20)/);
+      cy.get('#q').type('1518009510{enter}');
+      cy.url().should('include', '/subheadings/1518009510-80');
     });
 
     it('search navigates to short-form commodity codes', function() {


### PR DESCRIPTION
### Jira link

BAU

### What?

We have a failure in search suggestions tests which is only broken in production for
subheading suggestions with 10 digits.

These search suggestions are rare but we do have a test for the scenario
in which there is a 10 digit (as opposed to an 8 or 6 digit) subheading
suggestion and this should be robust enough not to fail when the
natural database ordering for suggestions changes

There are literally only 3 10-digit subheadings that don't also collide
with a commodity item id in the database:

```ruby
    const subheadings = [
      '1518009510',
      '1518009930',
      '1704909991',
    ];
```

This change will enable fewer random failures in this specific scenario

I fetched these with the following code snippet in the backend:

```ruby
declarable_ids = GoodsNomenclature.declarable.where(goods_nomenclatures__goods_nomenclature_item_id: SearchSuggestion.goods_nomenclature_type.where(value: /\d{10}/, goods_nomenclature_class: 'Subheading').pluck(:value)).pluck(:goods_nomenclature_item_id)
non_declarable_ids = SearchSuggestion.goods_nomenclature_type.where(value: /\d{10}/, goods_nomenclature_class: 'Subheading').pluck(:value)

non_declarable_ids - declarable_ids
```

I have added/removed/altered:

- [x] Fixed intermittent test failure

### Why?

I am doing this because:

- This is required to make sure we have a green production run
