### PR TITLE
BAU: Fixes regression specs

### DIFF
--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB-ASVX-SPQ-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB-ASVX-SPQ-e2e.cy.js
@@ -6,51 +6,36 @@ describe('| RoW-GB-ASVX-SPQ-e2e | AlcoholDuties |', function() {
     cy.selectDestination('gb');
     cy.originList({value: 'Antigua and Barbuda'});
     cy.customsValue({monetary: '500.00', shipping: '250.00', cost: '250.00'});
-  });
 
-  it('RoW 🇸🇬 Antigua and Barbuda - 🇬🇧 GB - Alcohol duties calculations for simple ASVX components', function() {
     // when I pick an asv percentage that applies a negative condition action
     cy.quantity({ltr: '1000', asv: '1.2', spr: '3'});
 
     // and I pick an excise code that picks a measure and applies the targeted conditions
-    cy.exciseCode('301');
+    cy.exciseCode('311');
     cy.confirmPage();
     cy.dutyPage();
 
     // then I should not see Excise calculations
     cy.should('not.contain', 'Excise');
 
+    cy.visit('/duty-calculator/measure-amount');
+  });
+
+  it('RoW 🇸🇬 Antigua and Barbuda - 🇬🇧 GB - Alcohol duties calculations for simple ASVX components', function() {
     // when I go back and pick an asv percentage that applies a positive condition action
-    cy.go('back');
-    cy.go('back');
-    cy.go('back');
-    cy.quantity({ltr: '1000', asv: '1.1', spr: '3'});
-    cy.exciseCode('301');
+    cy.quantity({ltr: '1000', asv: '3.49', spr: '5'});
+    cy.exciseCode('311');
     cy.confirmPage();
     cy.dutyPage();
 
     // then I should see Excise calculations
     cy.contains('Excise');
     cy.contains('9.27 GBP / % vol/hl');
-    cy.contains('£101.97'); // 9.27 * 1.1 * 10
+    cy.contains('£323.52'); // 9.27 * 3.49 * 10
   });
 
   it('RoW 🇸🇬 Antigua and Barbuda - 🇬🇧 GB - Alcohol duties calculations for SPQ-based components', function() {
-    // when I pick an asv percentage that applies a negative condition action
-    cy.quantity({ltr: '1000', asv: '1.2', spr: '5'});
-
-    // and I pick an excise code that picks a measure and applies the targeted conditions
-    cy.exciseCode('366');
-    cy.confirmPage();
-    cy.dutyPage();
-
-    // then I should not see Excise calculations
-    cy.should('not.contain', 'Excise');
-
     // when I go back and pick an asv percentage that applies a positive condition action
-    cy.go('back');
-    cy.go('back');
-    cy.go('back');
     cy.quantity({ltr: '1000', asv: '8.4', spr: '5'});
     cy.exciseCode('366');
     cy.confirmPage();

--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB-LPA-SPQ-e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB-LPA-SPQ-e2e.cy.js
@@ -6,51 +6,35 @@ describe('| RoW-GB-LPA-SPQ-e2e | AlcoholDuties |', function() {
     cy.selectDestination('gb');
     cy.originList({value: 'Antigua and Barbuda'});
     cy.customsValue({monetary: '500.00', shipping: '250.00', cost: '250.00'});
-  });
-
-  it('RoW 🇸🇬 Antigua and Barbuda - 🇬🇧 GB - Alcohol duties calculations for simple LPA components', function() {
     // when I pick an asv percentage that applies a negative condition action
-    cy.quantity({lpa: '1000', asv: '1.2', spr: '3'});
+    cy.quantity({lpa: '1000', asv: '3.5', spr: '3'});
 
     // and I pick an excise code that picks a measure and applies the targeted conditions
-    cy.exciseCode('301');
+    cy.exciseCode('314');
     cy.confirmPage();
     cy.dutyPage();
 
     // then I should not see Excise calculations
     cy.should('not.contain', 'Excise');
 
+    cy.visit('/duty-calculator/measure-amount');
+  });
+
+  it('RoW 🇸🇬 Antigua and Barbuda - 🇬🇧 GB - Alcohol duties calculations for simple LPA components', function() {
     // when I go back and pick an asv percentage that applies a positive condition action
-    cy.go('back');
-    cy.go('back');
-    cy.go('back');
-    cy.quantity({lpa: '1000', asv: '1.1', spr: '3'});
-    cy.exciseCode('301');
+    cy.quantity({lpa: '1000', asv: '3.49', spr: '3'});
+    cy.exciseCode('314');
     cy.confirmPage();
     cy.dutyPage();
 
     // then I should see Excise calculations
     cy.contains('Excise');
     cy.contains('9.27 GBP / l alc. 100%');
-    cy.contains('£9,270.00'); // 1000 * 1.1 * 9.27
+    cy.contains('£9,270.00'); // 9.27 * 1000
   });
 
   it('RoW 🇸🇬 Antigua and Barbuda - 🇬🇧 GB - Alcohol duties calculations for SPQ-based components', function() {
-    // when I pick an asv percentage that applies a negative condition action
-    cy.quantity({lpa: '1000', asv: '1.2', spr: '5'});
-
-    // and I pick an excise code that picks a measure and applies the targeted conditions
-    cy.exciseCode('370');
-    cy.confirmPage();
-    cy.dutyPage();
-
-    // then I should not see Excise calculations
-    cy.should('not.contain', 'Excise');
-
     // when I go back and pick an asv percentage that applies a positive condition action
-    cy.go('back');
-    cy.go('back');
-    cy.go('back');
     cy.quantity({lpa: '84', asv: '8.4', spr: '5'});
     cy.exciseCode('370');
     cy.confirmPage();

--- a/cypress/e2e/bulkSearch.cy.js
+++ b/cypress/e2e/bulkSearch.cy.js
@@ -1,4 +1,4 @@
-describe('POST /api/v2/bulk_searches', () => {
+describe('POST /api/v2/bulk_searches', {tags: ['notProduction']}, () => {
   it('should post a job and poll until it completes', () => {
     const bulkSearches = JSON.stringify({
       'data': [


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes alcohol calculations specs
- [x] Run bulk search specs only on staging

### Why?

I am doing this because:

- The production regression suite won't have access to bulk search for now
- These additional code choices for excise measures have had their duty amount changed to 0 so these are being filtered out
