### PR TITLE
BAU: Make expired subheading verification less brittle

### DIFF
--- a/cypress/e2e/frontend/exchange_rates/exchangeRatePageLoad.cy.js
+++ b/cypress/e2e/frontend/exchange_rates/exchangeRatePageLoad.cy.js
@@ -39,7 +39,7 @@ describe('validate /exchange_rates', function() {
     cy.get('h1[class=\'govuk-heading-l\']').contains('2023 HMRC currency exchange rates');
 
     // when I click through to the 2022 year
-    cy.get('li[class=\'gem-c-related-navigation__link\'] > a').contains('HMRC exchange rates for 2022').click();
+    cy.get('li[class=\'gem-c-related-navigation__link\'] > a').contains('2022').click();
 
     // and I see links for last year exchange rates
     cy.get('h1[class=\'govuk-heading-l\']').contains('2022 HMRC currency exchange rates');

--- a/cypress/e2e/legacySearch.cy.js
+++ b/cypress/e2e/legacySearch.cy.js
@@ -142,7 +142,7 @@ describe('Legacy search', function() {
 
     it('search navigates to 10 digit subheadings', function() {
       cy.get('#q').type('1518009510{enter}');
-      cy.url().should('include', '/subheadings/1518009510-80');
+      cy.url().should('match', /\/subheadings\/1518009510-(10|80)/);
     });
 
     it('search navigates to short-form commodity codes', function() {
@@ -164,7 +164,7 @@ describe('Legacy search', function() {
 
     it('search navigates to expired subheadings in their short form', function() {
       cy.get('#q').type('01029005{enter}');
-      cy.url().should('include', '/subheadings/0102900500-10');
+      cy.url().should('match', /\/subheadings\/0102900500-(10|80)/);
     });
 
     it('search navigates to expired subheadings in their long form', function() {


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes false-negative subheading regression failures in legacy search

### Why?

I am doing this because:

When someone inputs an ambigous short code for a subheading that has
multiple subheadings with the same short code in its tree we'll rely
on the natural order in the database for fetching the either of the
relevant subheadings

This creates a non-deterministic situation whereby the subheading PLS
might change depending on the ordering.

Technically we can't say either is right since the short code is
ambigous so we just accept that any are right.
