### PR TITLE
HOTT-4104 bug fix for text display as ‘not at risk’ 

### DIFF
--- a/cypress/e2e/UK/FE/switchingLinks-UK.cy.js
+++ b/cypress/e2e/UK/FE/switchingLinks-UK.cy.js
@@ -17,7 +17,7 @@ describe('switching links uk', function() {
     cy.get('.govuk-main-wrapper')
         .contains('Northern Ireland Online Tariff');
     cy.get('.govuk-main-wrapper')
-        .contains('if your goods are not ‘at risk’ of onward movement to the EU').click();
+        .contains('if your goods are ‘not at risk’ of onward movement to the EU').click();
     cy.contains('Declaring goods you bring into Northern Ireland \'not at risk’ of moving to the EU');
 
     cy.title().should('eq', 'Declaring goods you bring into Northern Ireland \'not at risk’ of moving to the EU - GOV.UK');


### PR DESCRIPTION

### [Jira](https://transformuk.atlassian.net/browse/HOTT-4104) link

[HOTT-<4104>](https://transformuk.atlassian.net/browse/HOTT-4104)

### What?

I have added/removed/altered:
Updated the text display as 'not at risk' in the spec file 'switchingLinks-UK.cy.js' for commodity page in uk


### Why?

I am doing this because: 
To fix staging regression failures related to this [HOTT-4104](https://transformuk.atlassian.net/browse/HOTT-4104)
