### PR TITLE
adds a new test for UKIMS or UKTS before 30 Sept 2023

### DIFF
--- a/cypress/e2e/DutyCalculator/dcShared/dcTraderScheme.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcTraderScheme.cy.js
@@ -118,4 +118,48 @@ describe('💷  | dcTraderScheme | UK Internal Market Scheme page |', function()
     cy.contains('Apply for authorisation for the UK Internal Market Scheme').click();
     cy.contains('Windsor Framework unveiled to fix problems of the Northern Ireland Protocol');
   });
+  it('NI - Page Validation for UKIMS or UKTS before 30 Sept 2023', function() {
+    cy.visit('/duty-calculator/uk/0702000007/import-date');
+    cy.enterDate({day: '19', month: '09', year: '2023'});
+    cy.contains('Continue').click();
+
+    cy.contains('Which part of the UK are you importing into?');
+    cy.get('#steps-import-destination-import-destination-xi-field').check();
+    cy.contains('Continue').click();
+    cy.contains('Which country are the goods coming from?');
+
+    cy.get('input#steps-country-of-origin-country-of-origin-gb-field').click();
+    cy.contains('Continue').click();
+
+    // trader page
+    cy.contains('Were you authorised under the UK Trader Scheme (UKTS) or the UK Internal Market Scheme (UKIMS)?');
+    cy.contains('If you were moving goods into Northern Ireland which are for sale to, or final use by, ');
+    cy.contains('end consumers located in the UK and you were authorised under the UK Trader Scheme or the UK Internal Market Scheme, ');
+    cy.contains('then you may declare your goods as being \'not at risk\' where the requirements are met. ');
+    cy.contains('A \'not at risk\' good entering Northern Ireland from Great Britain will not be subject to duty.');
+
+    cy.contains('Yes, I was authorised under the UK Trader Scheme or UK Internal Market Scheme at the time of the trade');
+    cy.contains('No, I was not authorised under the UK Trader Scheme or UK Internal Market Scheme at the time of the trade');
+    cy.contains('Please note that UK Internal Market scheme trades cannot benefit from expanded processing rules before 30 September 2023');
+    cy.contains('Trades before this date will use the UK Trader Scheme rules on processing');
+
+    // Select Yes, I am registered with the UK Trader Scheme (UKTS) or the UK Internal Market Scheme (UKIMS)
+    cy.traderScheme('yes');
+    // selection is persisted
+    cy.get('.govuk-back-link').click();
+    cy.get('div:nth-of-type(1) > input[name=\'steps_trader_scheme[trader_scheme]\']')
+        .parent()
+        .find('input')
+        .should('be.checked');
+
+    // Select No,I am not registered with the UK Trader Scheme (UKTS) or the UK Internal Market Scheme (UKIMS)
+    cy.traderScheme('no');
+    // selection is persisted
+
+    cy.get('.govuk-back-link').click();
+    cy.get('div:nth-of-type(2) > input[name=\'steps_trader_scheme[trader_scheme]\']')
+        .parent()
+        .find('input')
+        .should('be.checked');
+  });
 });

--- a/cypress/e2e/UK/API/V2/jsonapi_validations.cy.js
+++ b/cypress/e2e/UK/API/V2/jsonapi_validations.cy.js
@@ -299,7 +299,7 @@ describe('Api validations', function() {
     it('returns a valid jsonapi response', function() {
       cy.request(path).then((response) => {
         cy.validJsonAPIresponse(response);
-      });     
+      });
     });
   });
 });

--- a/cypress/e2e/XI/API/V2/jsonapi_validations.cy.js
+++ b/cypress/e2e/XI/API/V2/jsonapi_validations.cy.js
@@ -299,7 +299,7 @@ describe('Api validations', function() {
     it('returns a valid jsonapi response', function() {
       cy.request(path).then((response) => {
         cy.validJsonAPIresponse(response);
-      });     
+      });
     });
   });
 });


### PR DESCRIPTION
### Jira link

[HOTT-4070](https://transformuk.atlassian.net/browse/HOTT-4070)

### What?

I have added/removed/altered:

- Added a new automated test to cover duty calculator scenario for UKTS or UKIMS scheme before 30 Sept 2023
- Fixed linting issues with API spec files

### Why?

I am doing this because:

- To keep regression tests up to date with the front end changes and validate all changes to ensure that we have coverage for all major changes in the duty calculator application.