### PR TITLE
fix staging regression failure

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -278,9 +278,9 @@ describe('Using beta search', {tags: ['devOnly']}, function() {
       cy.url().should('include', '/subheadings/2007995000-80');
     });
 
-    it('search navigates to 10 digit subheadings', function() {
+    it.only('search navigates to 10 digit subheadings', function() {
       cy.get('#q').type('2007993916{enter}');
-      cy.url().should('match', /\/subheadings\/2007993916-(10|20)/);
+      cy.url().should('match', /\/subheadings\/2007993916-(10|20|30)/);
     });
 
     it('search navigates to short-form commodity codes', function() {


### PR DESCRIPTION
Jira link

- BAU

What?
I have added/removed/altered:

- Fixed regression failure related to 10 digits subheading search on the staging environment.

Why?
I am doing this because:

- To ensure that we get a green build overnight when the staging regression suite is triggered.