### PR TITLE
fix for regression failure to make the build green

### DIFF
--- a/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB208--e2e.cy.js
+++ b/cypress/e2e/DutyCalculator/2.RoW-GB/RoW-GB208--e2e.cy.js
@@ -21,8 +21,8 @@ describe('| RoW-GB208--e2e.spec | Special calculations - alcohol % + sugar % |',
     cy.contains('£2,274.42');
     // tariff preference rate for Singapore
     cy.contains('Tariff preference - Singapore');
-    cy.contains('0.10 GBP / % vol/hl + 0.80 GBP / hl');
-    cy.contains('£2,212.50');
+    cy.contains('0.00 GBP / % vol/hl + 0.40 GBP / hl');
+    cy.contains('£2,197.62');
   });
 
   // alcohol percentage calculations


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4424

HOTT-<4424>

### What?

I have added/removed/altered:

Updated the spec RoW-GB208--e2e.spec to fix the regression issue

### Why?

I am doing this because:

to make sure the stagging regression build is always green
