### PR TITLE
BAU: Disable beta search

### DIFF
--- a/cypress/e2e/betaSearch.cy.js
+++ b/cypress/e2e/betaSearch.cy.js
@@ -1,4 +1,4 @@
-describe('Using beta search', {tags: ['devOnly']}, function() {
+describe.skip('Using beta search', {tags: ['devOnly']}, function() {
   beforeEach(function() {
     cy.visit('/find_commodity');
     cy.visit('/search/toggle_beta_search');


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Disabled beta search tests

### Why?

I am doing this because:

- Beta search has been disabled until we've had the legacy search fixes validated by the HMRC team on development
