### PR TITLE
adds new automated tests for admin search references

### DIFF
--- a/cypress/e2e/smoketests/adminSmokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/adminSmokeTestCI.cy.js
@@ -18,6 +18,18 @@ describe('Admin tool smoke tests', {tags: ['adminOnly']}, function() {
       cy.verifySearchReferencesHeading(service);
     });
 
+    it('verify import search references and click back button', function() {
+      cy.verifyImportSearchReferencesPageAndClkBackBtn(service);
+    });
+
+    it('verify import search references and click import references button', function() {
+      cy.verifyImportSearchReferencesPageAndClkImportRefsBtn(service);
+    });
+
+    it('verify export all search references as a CSV button', function() {
+      cy.verifyExportAllSearchReferencesAsCSVBtn(service);
+    });
+
     it('verify rollbacks', function() {
       cy.verifyRollbacks(service);
     });
@@ -64,6 +76,18 @@ describe('Admin tool smoke tests', {tags: ['adminOnly']}, function() {
 
     it('verify search references heading', function() {
       cy.verifySearchReferencesHeading(service);
+    });
+
+    it('verify import search references and click back button', function() {
+      cy.verifyImportSearchReferencesPageAndClkBackBtn(service);
+    });
+
+    it('verify import search references and click import references button', function() {
+      cy.verifyImportSearchReferencesPageAndClkImportRefsBtn(service);
+    });
+
+    it('verify export all search references as a CSV button', function() {
+      cy.verifyExportAllSearchReferencesAsCSVBtn(service);
     });
 
     it('verify rollbacks', function() {

--- a/cypress/support/adminCommands.js
+++ b/cypress/support/adminCommands.js
@@ -84,6 +84,52 @@ Cypress.Commands.add('verifySearchReferencesHeading', (service) => {
   cy.get('#main-content > div.govuk-auto-classes > table').contains('Actions');
 });
 
+Cypress.Commands.add('verfiySearchReferences', (service) => {
+  cy.visit(`${adminUrl}/${service}/search_references/sections`);
+  cy.verifyService(service);
+  cy.contains('Import and Export search references');
+  cy.contains('Import multiple search references from a CSV file');
+  cy.contains('Import search references CSV');
+  cy.contains('Export all search references as a CSV file');
+  cy.contains('Export all search references as a CSV');
+});
+
+Cypress.Commands.add('verifyImportSearchReferencesPageAndClkBackBtn', (service) => {
+  cy.visit(`${adminUrl}/${service}/search_references/sections`);
+  cy.verifyService(service);
+  cy.verfiySearchReferences(service);
+  cy.contains('Import search references CSV').click();
+  cy.url().should('include', '/search_references/import');
+  cy.contains('Import search references');
+  cy.get('#new_import_task').contains('Sample CSV file:');
+  cy.contains('Upload CSV with search references. Search references are overriden if ID is provided');
+  cy.get('#import-task-file-field').should('be.visible');
+  cy.contains('Back').click();
+  cy.url().should('include', '/search_references/sections');
+  cy.verfiySearchReferences(service);
+});
+
+Cypress.Commands.add('verifyImportSearchReferencesPageAndClkImportRefsBtn', (service) => {
+  cy.visit(`${adminUrl}/${service}/search_references/sections`);
+  cy.verifyService(service);
+  cy.verfiySearchReferences(service);
+  cy.contains('Import search references CSV').click();
+  cy.url().should('include', '/search_references/import');
+  cy.contains('Import search references');
+  cy.get('#new_import_task').contains('Sample CSV file:');
+  cy.contains('Upload CSV with search references. Search references are overriden if ID is provided');
+  cy.get('#import-task-file-field').should('be.visible');
+  cy.contains('Back');
+  cy.contains('Import references from CSV').click();
+});
+
+Cypress.Commands.add('verifyExportAllSearchReferencesAsCSVBtn', (service) => {
+  cy.visit(`${adminUrl}/${service}/search_references/sections`);
+  cy.verifyService(service);
+  cy.verfiySearchReferences(service);
+  cy.contains('Export all search references as a CSV').click();
+});
+
 Cypress.Commands.add('createNewsItem', (service) => {
   cy.visit(`${adminUrl}/${service}/news_items`);
   cy.contains('Manage news stories');


### PR DESCRIPTION
### Jira link

- HOTT-4867
- HOTT-4868

### What?

I have added/removed/altered:

- Added new automated tests for admin search references import and export functionality.
- Added new commands for admin search references for import and export to verify the different text and buttons etc.

### Why?

I am doing this because:

- To ensure that we have enough test coverage for import and export search references functionality.