### PR TITLE
Gl 503 category assessments

### DIFF
--- a/cypress/support/adminCommands.js
+++ b/cypress/support/adminCommands.js
@@ -429,7 +429,7 @@ Cypress.Commands.add('verifyNewCategoryAssessmentPage', (service) => {
   cy.get('#category-assessment-regulation-id-error').contains('Regulation is not present');
   cy.get('#category-assessment-regulation-role-error').contains('Regulation role is not present');
   cy.get('#category-assessment-theme-id-error').contains('Theme is not present');
-  //verify the Category Assessment hyperlink functionality
+  //verify the Category Assessment hyperlink functionality in NewCategoryAssessmentPage
   cy.get('.govuk-breadcrumbs__link').should("have.attr", "href", "/xi/green_lanes/category_assessments").click();
   cy.url().should('include', '/xi/green_lanes/category_assessments');
   cy.contains('Manage category assessments');

--- a/cypress/support/adminCommands.js
+++ b/cypress/support/adminCommands.js
@@ -429,6 +429,11 @@ Cypress.Commands.add('verifyNewCategoryAssessmentPage', (service) => {
   cy.get('#category-assessment-regulation-id-error').contains('Regulation is not present');
   cy.get('#category-assessment-regulation-role-error').contains('Regulation role is not present');
   cy.get('#category-assessment-theme-id-error').contains('Theme is not present');
+  //verify the Category Assessment hyperlink functionality
+  cy.get('.govuk-breadcrumbs__link').should("have.attr", "href", "/xi/green_lanes/category_assessments").click();
+  cy.url().should('include', '/xi/green_lanes/category_assessments');
+  cy.contains('Manage category assessments');
+  cy.contains('Add a Category Assessment').click();
   cy.contains('Back').click();
   cy.contains('Manage category assessments');
   cy.contains('Add a Category Assessment');

--- a/cypress/support/adminCommands.js
+++ b/cypress/support/adminCommands.js
@@ -429,8 +429,8 @@ Cypress.Commands.add('verifyNewCategoryAssessmentPage', (service) => {
   cy.get('#category-assessment-regulation-id-error').contains('Regulation is not present');
   cy.get('#category-assessment-regulation-role-error').contains('Regulation role is not present');
   cy.get('#category-assessment-theme-id-error').contains('Theme is not present');
-  //verify the Category Assessment hyperlink functionality in NewCategoryAssessmentPage
-  cy.get('.govuk-breadcrumbs__link').should("have.attr", "href", "/xi/green_lanes/category_assessments").click();
+  // verify the Category Assessment hyperlink functionality in NewCategoryAssessmentPage
+  cy.get('.govuk-breadcrumbs__link').should('have.attr', 'href', '/xi/green_lanes/category_assessments').click();
   cy.url().should('include', '/xi/green_lanes/category_assessments');
   cy.contains('Manage category assessments');
   cy.contains('Add a Category Assessment').click();


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/GL-503
OTT-<GL-503>

### What?

I have added/removed/altered:

Added missed functionality to verify the Category Assessment hyperlink in NewCategoryAssessmentPage for 
adminSmokeTestCI.cy for the test service verifyNewCategoryAssessmentPage

### Why?

I am doing this because:
Cover all the functionality as part of new changes in admin for NewCategoryAssessmentPage and make sure the regression test coverage to reduce the defect leakage


