### PR TITLE
Increase cypress verify timeout

### DIFF
--- a/.github/workflows/regressionProduction.yml
+++ b/.github/workflows/regressionProduction.yml
@@ -10,6 +10,7 @@ jobs:
       CYPRESS_BASE_URL: "https://www.trade-tariff.service.gov.uk"
       CYPRESS_SPACE: "PRODUCTION"
       CYPRESS_grepTags: "-devOnly+-smokeTest+-notProduction+-adminOnly"
+      CYPRESS_VERIFY_TIMEOUT: 60000
     name: "🚦 Regression Tests - UK and XI"
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/regressionStaging.yml
+++ b/.github/workflows/regressionStaging.yml
@@ -19,6 +19,7 @@ jobs:
       CYPRESS_STAGING_BASIC_PASSWORD: ${{ secrets.CYPRESS_STAGING_BASIC_PASSWORD }}
       CYPRESS_STAGING_BASIC_USERNAME: ${{ secrets.CYPRESS_STAGING_BASIC_USERNAME }}
       CYPRESS_grepTags: "-smokeTest+-notStaging"
+      CYPRESS_VERIFY_TIMEOUT: 60000
     name: "RegressionTests - Staging"
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
### Jira link

- https://transformuk.atlassian.net/browse/OTT-305

### What?

I have added/removed/altered:

- Added new environment variable in the GitHub workflows to avoid cypress verification timed-out issue while running the workflows in the GiHub Actions.

### Why?

I am doing this because:

- To ensure that we get a green build for regression suites.