### PR TITLE
fixed staging_RegressionFailures as per new changes for commodity page

### DIFF
--- a/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
+++ b/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
@@ -25,11 +25,11 @@ describe('commodity supplementary units', function() {
       // when I select a country that has a supplementary unit
       cy.visit('/uk/commodities/1704909912?country=CR');
       // then I should see the supplementary unit
-      cy.get('.autocomplete__wrapper').contains('Costa Rica');
+      cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('Costa Rica');
       cy.contains('Kilogram (kg/raw sugar)');
       // when I select no country
       cy.visit('/uk/commodities/1704909912');
-      cy.get('.autocomplete__wrapper').contains('All countries');
+      cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('All countries');
       // then I should see the no supplementary unit message
       cy.contains('There are no supplementary units globally assigned to this commodity. Select a country of import / export to check');
       cy.contains('on supplementary units for a specific country, or scroll down to the import duties section.');
@@ -67,11 +67,11 @@ describe('commodity supplementary units', function() {
       // when I select a country that has a supplementary unit
       cy.visit('/xi/commodities/1704909912?country=CR');
       // then I should see the supplementary unit
-      cy.get('.autocomplete__wrapper').contains('Costa Rica');
+      cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('Costa Rica');
       cy.contains('Kilogram (kg/raw sugar)');
       // when I select no country
       cy.visit('/xi/commodities/1704909912');
-      cy.get('.autocomplete__wrapper').contains('All countries');
+      cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('All countries');
       // then I should see the no supplementary unit message
       cy.contains('There are no supplementary units globally assigned to this commodity. Select a country of import / export to check');
       cy.contains('on supplementary units for a specific country, or scroll down to the import duties section.');

--- a/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
+++ b/cypress/e2e/HOTT-Shared/supplementaryUnits.cy.js
@@ -25,11 +25,11 @@ describe('commodity supplementary units', function() {
       // when I select a country that has a supplementary unit
       cy.visit('/uk/commodities/1704909912?country=CR');
       // then I should see the supplementary unit
-      cy.get('.govuk-summary-list__value').contains('Costa Rica');
+      cy.get('.autocomplete__wrapper').contains('Costa Rica');
       cy.contains('Kilogram (kg/raw sugar)');
       // when I select no country
       cy.visit('/uk/commodities/1704909912');
-      cy.get('.govuk-summary-list__value').contains('All countries');
+      cy.get('.autocomplete__wrapper').contains('All countries');
       // then I should see the no supplementary unit message
       cy.contains('There are no supplementary units globally assigned to this commodity. Select a country of import / export to check');
       cy.contains('on supplementary units for a specific country, or scroll down to the import duties section.');
@@ -67,11 +67,11 @@ describe('commodity supplementary units', function() {
       // when I select a country that has a supplementary unit
       cy.visit('/xi/commodities/1704909912?country=CR');
       // then I should see the supplementary unit
-      cy.get('.govuk-summary-list__value').contains('Costa Rica');
+      cy.get('.autocomplete__wrapper').contains('Costa Rica');
       cy.contains('Kilogram (kg/raw sugar)');
       // when I select no country
       cy.visit('/xi/commodities/1704909912');
-      cy.get('.govuk-summary-list__value').contains('All countries');
+      cy.get('.autocomplete__wrapper').contains('All countries');
       // then I should see the no supplementary unit message
       cy.contains('There are no supplementary units globally assigned to this commodity. Select a country of import / export to check');
       cy.contains('on supplementary units for a specific country, or scroll down to the import duties section.');

--- a/cypress/e2e/UK/FE/countrySelection-UK.cy.js
+++ b/cypress/e2e/UK/FE/countrySelection-UK.cy.js
@@ -25,14 +25,14 @@ describe('🇬🇧 💡 | countrySelection-UK | Country Selection |', {tags: ['c
     cy.contains('You are currently using the UK Integrated Online Tariff');
     cy.contains('Select or enter a country name to view UK measures');
     cy.countryPickerpage({value: 'Argentina'});
-    cy.get('.autocomplete__wrapper').contains('Argentina (AR)');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('Argentina (AR)');
     // Typing the country code
     cy.get('input#trading_partner_country').click();
     cy.countryPickerpage({value: '(DE)'});
-    cy.get('.autocomplete__wrapper').contains('Germany (DE)');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('Germany (DE)');
     // reset to all countries
     cy.get('a[href*="/commodities/"]').contains('Reset to all countries').click();
-    cy.get('.autocomplete__wrapper').contains('All countries');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('All countries');
   });
   it('UK Country selection page - No country selected ', function() {
     cy.visit('/commodities/0804100030');
@@ -44,6 +44,6 @@ describe('🇬🇧 💡 | countrySelection-UK | Country Selection |', {tags: ['c
     cy.countryPickerpage({value: '(DE)'});
     // Reset all countries
     cy.get('.govuk-link').contains('Reset to all countries').click();
-    cy.get('.autocomplete__wrapper').contains('All countries');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('All countries');
   });
 });

--- a/cypress/e2e/UK/FE/countrySelection-UK.cy.js
+++ b/cypress/e2e/UK/FE/countrySelection-UK.cy.js
@@ -22,33 +22,28 @@ describe('🇬🇧 💡 | countrySelection-UK | Country Selection |', {tags: ['c
 
   it('UK Country selection page', function() {
     cy.visit('/commodities/0804100030');
-    cy.get('a[href*="/trading"]').contains('Change').click();
-    cy.contains('View UK measures for the selected country');
-    cy.contains('UK Integrated Online Tariff');
-    cy.title().should('eq', 'UK Integrated Online Tariff - Set country filter - GOV.UK');
+    cy.contains('You are currently using the UK Integrated Online Tariff');
+    cy.contains('Select or enter a country name to view UK measures');
     cy.countryPickerpage({value: 'Argentina'});
-    cy.get('.govuk-summary-list').contains('Argentina');
     cy.get('.autocomplete__wrapper').contains('Argentina (AR)');
     // Typing the country code
-    cy.get('a[href*="/trading"]').contains('Change').click();
+    cy.get('input#trading_partner_country').click();
     cy.countryPickerpage({value: '(DE)'});
-    cy.get('.govuk-summary-list').contains('Germany');
+    cy.get('.autocomplete__wrapper').contains('Germany (DE)');
     // reset to all countries
     cy.get('a[href*="/commodities/"]').contains('Reset to all countries').click();
-    cy.get('.govuk-summary-list').contains('All countries');
+    cy.get('.autocomplete__wrapper').contains('All countries');
   });
   it('UK Country selection page - No country selected ', function() {
     cy.visit('/commodities/0804100030');
-    cy.get('a[href*="/trading"]').contains('Change').click();
-    cy.contains('View UK measures for the selected country');
-    cy.contains('Continue').click();
-    cy.get('.govuk-error-summary');
-    cy.contains('There is a problem');
-    cy.contains('Select a country');
-    cy.get('.govuk-error-message')
-        .contains('Select a country');
+    cy.contains('You are currently using the UK Integrated Online Tariff');
+    cy.contains('Select or enter a country name to view UK measures');
+    cy.get('#tab_rules-of-origin').click();
+    cy.get('.govuk-grid-column-full > .govuk-warning-text > .govuk-warning-text__text').contains('Select a country to check which tariff treatments apply.');
+    cy.get('input#trading_partner_country').click();
+    cy.countryPickerpage({value: '(DE)'});
     // Reset all countries
     cy.get('.govuk-link').contains('Reset to all countries').click();
-    cy.get('.govuk-summary-list').contains('All countries');
+    cy.get('.autocomplete__wrapper').contains('All countries');
   });
 });

--- a/cypress/e2e/UK/FE/pages-UK.cy.js
+++ b/cypress/e2e/UK/FE/pages-UK.cy.js
@@ -128,7 +128,7 @@ describe('🇬🇧 💡 | pages-UK.spec | Main Page - headers ,sections  - (UK v
         .contains('You will then be able to check in the Origin tab if preferential tariff treatments apply to this specific commodity.');
     cy.get('input#trading_partner_country').click();
     cy.countryPickerpage({value: 'Argentina'});
-    cy.get('.autocomplete__wrapper').contains('Argentina (AR)');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('Argentina (AR)');
     cy.get('a#tab_import').click();
   });
   it('UK - Rules of origin - duty drawback - help page', {tags: ['notProduction']}, function() {

--- a/cypress/e2e/UK/FE/pages-UK.cy.js
+++ b/cypress/e2e/UK/FE/pages-UK.cy.js
@@ -126,9 +126,8 @@ describe('🇬🇧 💡 | pages-UK.spec | Main Page - headers ,sections  - (UK v
     cy.get('#import > :nth-child(2)').contains('Select a country to view country-specific import information.');
     cy.get('#import > :nth-child(3)')
         .contains('You will then be able to check in the Origin tab if preferential tariff treatments apply to this specific commodity.');
-    cy.get('a[href^=\'/trading_partners\']').click();
+    cy.get('input#trading_partner_country').click();
     cy.countryPickerpage({value: 'Argentina'});
-    cy.get('.govuk-summary-list__value').contains('Argentina').should('be.visible');
     cy.get('.autocomplete__wrapper').contains('Argentina (AR)');
     cy.get('a#tab_import').click();
   });

--- a/cypress/e2e/XI/FE/countrySelection-XI.cy.js
+++ b/cypress/e2e/XI/FE/countrySelection-XI.cy.js
@@ -27,33 +27,26 @@ describe('🇪🇺 💡 | countrySelection-XI | Country Selection |', {tags: ['c
   // no XU
   it('XI Country selection page', function() {
     cy.visit('xi/commodities/0804100030');
-    cy.get('a[href*="/xi/trading"]').contains('Change').click();
-    cy.contains('View EU and UK measures for the selected country');
-    cy.contains('Northern Ireland Online Tariff');
-    cy.title().should('eq', 'Northern Ireland Online Tariff - Set country filter - GOV.UK');
+    cy.contains('You are currently using the Northern Ireland Online Tariff');
+    cy.contains('Select or enter a country name to view EU and UK measures');
     cy.countryPickerpage({value: 'Argentina'});
-    cy.get('.govuk-summary-list').contains('Argentina');
     cy.get('.autocomplete__wrapper').contains('Argentina (AR)');
     // Typing the country code
-    cy.get('a[href*="/xi/trading"]').contains('Change').click();
+    cy.get('input#trading_partner_country').click();
     cy.countryPickerpage({value: '(DE)'});
-    cy.get('.govuk-summary-list').contains('Germany');
+    cy.get('.autocomplete__wrapper').contains('Germany');
     // reset to all countries
     cy.get('a[href*="/commodities/"]').contains('Reset to all countries').click();
-    cy.get('.govuk-summary-list').contains('All countries');
+    cy.get('.autocomplete__wrapper').contains('All countries');
   });
   it('XI Country selection page - No country selected ', function() {
     cy.visit('xi/commodities/0804100030');
-    cy.get('a[href*="/xi/trading"]').contains('Change').click();
-    cy.contains('View EU and UK measures for the selected country');
-    cy.contains('Continue').click();
-    cy.get('.govuk-error-summary');
-    cy.contains('There is a problem');
-    cy.contains('Select a country');
-    cy.get('.govuk-error-message')
-        .contains('Select a country');
+    cy.contains('You are currently using the Northern Ireland Online Tariff');
+    cy.contains('Select or enter a country name to view EU and UK measures');
+    cy.get('#tab_rules-of-origin').click();
+    cy.contains('#rules-of-origin', 'Select a country to check which tariff treatments apply.').should('not.exist');  
     // Reset all countries
     cy.get('.govuk-link').contains('Reset to all countries').click();
-    cy.get('.govuk-summary-list').contains('All countries');
+    cy.get('.autocomplete__wrapper').contains('All countries');
   });
 });

--- a/cypress/e2e/XI/FE/countrySelection-XI.cy.js
+++ b/cypress/e2e/XI/FE/countrySelection-XI.cy.js
@@ -30,14 +30,14 @@ describe('🇪🇺 💡 | countrySelection-XI | Country Selection |', {tags: ['c
     cy.contains('You are currently using the Northern Ireland Online Tariff');
     cy.contains('Select or enter a country name to view EU and UK measures');
     cy.countryPickerpage({value: 'Argentina'});
-    cy.get('.autocomplete__wrapper').contains('Argentina (AR)');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('Argentina (AR)');
     // Typing the country code
     cy.get('input#trading_partner_country').click();
     cy.countryPickerpage({value: '(DE)'});
-    cy.get('.autocomplete__wrapper').contains('Germany');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('Germany');
     // reset to all countries
     cy.get('a[href*="/commodities/"]').contains('Reset to all countries').click();
-    cy.get('.autocomplete__wrapper').contains('All countries');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('All countries');
   });
   it('XI Country selection page - No country selected ', function() {
     cy.visit('xi/commodities/0804100030');
@@ -47,6 +47,6 @@ describe('🇪🇺 💡 | countrySelection-XI | Country Selection |', {tags: ['c
     cy.contains('#rules-of-origin', 'Select a country to check which tariff treatments apply.').should('not.exist');  
     // Reset all countries
     cy.get('.govuk-link').contains('Reset to all countries').click();
-    cy.get('.autocomplete__wrapper').contains('All countries');
+    cy.get('.autocomplete__wrapper > ul >li.autocomplete__option').contains('All countries');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -38,14 +38,15 @@ Cypress.Commands.add('datePickerPage', (date) => {
 
 Cypress.Commands.add('countryPickerpage', (country) => {
   cy.contains('Select a country');
-  cy.get('input#trading-partner-country-field').click();
-  cy.get('input#trading-partner-country-field').clear();
-  cy.get('input#trading-partner-country-field').type(country.value);
-  cy.get('#trading-partner-country-field__listbox').contains(country.value).click();
-  cy.contains('Continue').click();
+
+  cy.get('input#trading_partner_country').click();
+  cy.get('input#trading_partner_country').clear();
+  cy.get('input#trading_partner_country').type(country.value);
+  cy.get('[id=\'trading_partner_country__listbox\']').contains(country.value).click();
 });
 
 Cypress.Commands.add('verifyCountrySelection', (country, txt) => {
+  cy.contains('Select a country');
   cy.get('input#trading_partner_country').click();
   cy.get('input#trading_partner_country').clear();
   cy.get('input#trading_partner_country').type(`${country}`);


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/OTT-323
OTT-<323>

### What?

I have added/removed/altered:

Updated tests as per the new changes for the commodity page as part of staging regression failures

### Why?

Ensure we get a green build overnight when the staging regression suite is triggered.
