### PR TITLE
BAU: Fixes broken smoke tests

### DIFF
--- a/cypress/e2e/smoketests/smokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/smokeTestCI.cy.js
@@ -19,7 +19,7 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.searchForCommodity('3808941000');
       cy.get('.govuk-heading-l.commodity-header').contains(/Commodity .*3808941000/i);
       cy.contains('21 December 2022');
-      cy.get('a[href=\'/import_export_dates?day=21&month=12&year=2022\']').click();
+      cy.get('a[href=\'/import_export_dates?day=21&goods_nomenclature_code=3808941000&month=12&year=2022\']').click();
       cy.datePickerPage({day: 22, month: 12, year: 2022});
       cy.contains('22 December 2022');
     });
@@ -244,7 +244,7 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.searchForCommodity('3808941000');
       cy.get('.govuk-heading-l.commodity-header').contains(/Commodity .*3808941000/i);
       cy.contains('21 December 2022');
-      cy.get('a[href=\'/xi/import_export_dates?day=21&month=12&year=2022\']').click();
+      cy.get('a[href=\'/xi/import_export_dates?day=21&goods_nomenclature_code=3808941000&month=12&year=2022\']').click();
       cy.datePickerPage({day: 22, month: 12, year: 2022});
       cy.contains('22 December 2022');
     });


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixed smoke tests that verify import_export_date paths

### Why?

I am doing this because:

To support multiple tabs simultaneously, we have to make the storage of
goods nomenclature codes stateless (in the URL path as opposed to in the
session of the requests).

This means that on several pages with back links to goods nomenclature
and on forms, we have links rendered that include the
goods_nomenclature_code in the path and as hidden fields to
PATCH/POST/PUT in form submits.
