### PR TITLE
BAU: Fixes missed search query parser specs

### DIFF
--- a/cypress/e2e/smoketests/infrastructureSmokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/infrastructureSmokeTestCI.cy.js
@@ -1,14 +1,4 @@
 describe('Smoke tests for infrastructure', function() {
-  it('returns healthy for the search query parser', function() {
-    cy.request('/api/search/healthcheck').then((response) => {
-      expect(response.status).to.eq(200);
-      expect(response.body).to.have.property('git_sha1');
-      expect(response.body.healthy).to.eq(true);
-      expect(response.body.using_spelling_fallback).to.eq(false);
-      expect(response.body.using_synonym_fallback).to.eq(false);
-    });
-  });
-
   it('returns healthy for the frontend', function() {
     cy.request('/healthcheck').then((response) => {
       expect(response.status).to.eq(200);


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removed redundant/failing smoke test of the search query parser

### Why?

I am doing this because:

- This service is no longer live
