### PR TITLE
OTT-351 Updated Commodity Picker to use Stimulus component

### DIFF
--- a/cypress/e2e/HOTT-Shared/sectionsPage-UKXI.cy.js
+++ b/cypress/e2e/HOTT-Shared/sectionsPage-UKXI.cy.js
@@ -5,7 +5,7 @@ describe('🇬🇧 💡 🔍  | sectionsPage.spec-UK | Sections page content val
     it(`${country[i]} Search the tariff text/box visible`, function() {
       cy.visit(`${country[i]}/sections`);
       cy.get('.govuk-label').should('be.visible');
-      cy.get('.js-commodity-picker-select.js-show  input#q').should('be.visible');
+      cy.get('[data-controller="commodity-select-box"] input#q').should('be.visible');
     });
     it(`${country[i]} Browse Page - All 21 sections titles displayed `, function() {
       cy.visit(`${country[i]}/browse`);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -123,13 +123,13 @@ Cypress.Commands.add('contextSelector', () => {
 });
 
 Cypress.Commands.add('searchForCommodity', (searchString) => {
-  cy.get('.js-commodity-picker-select:last').click();
-  cy.get('.js-commodity-picker-select:last').type(`${searchString}{enter}`);
+  cy.get('[data-controller="commodity-select-box"] .autocomplete__input--default').click();
+  cy.get('[data-controller="commodity-select-box"] .autocomplete__input--default').type(`${searchString}{enter}`);
 });
 
 Cypress.Commands.add('searchForCommodity2', (searchString) => {
-  cy.get('.js-commodity-picker-select:last').click();
-  cy.get('.js-commodity-picker-select:last').type(searchString);
+  cy.get('[data-controller="commodity-select-box"] .autocomplete__input--default').click();
+  cy.get('[data-controller="commodity-select-box"] .autocomplete__input--default').type(searchString);
   return cy.get('input[name=\'new_search\']').click();
 });
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTT-351

### What?

I have altered

- [x] tests to use data-controller="commodity-select-box instead of .js-commodity-picker-select

### Why?

I am doing this because:

- The component has been migrated to a stimulus component

### Have you? (optional)

- [x] Created clear commits for traceability?
- [x] Avoided brittle tests which need constant fixing due to data/or static content changes?
- [x] Made sure there isn't already a test for this feature?
- [x] Avoided testing logic that isn't part of an integration between multiple systems and that is effectively a unit test in the application already?
- [x] Reviewed changes with affected stakeholders?
