### PR TITLE
added new smoke tests for green lanes standard category scenarios

### DIFF
--- a/cypress/e2e/smoketests/smokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/smokeTestCI.cy.js
@@ -4,7 +4,7 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.visit('/find_commodity');
       cy.mainPageUK();
     });
-    it('verify date pickers are working', function() {
+    it('Verify date pickers are working', function() {
       cy.visit('/find_commodity');
       cy.get('.govuk-details__summary').click();
       cy.get('#tariff_date_day').click();
@@ -407,6 +407,94 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.contains('Continue').click();
       cy.get('.govuk-button:not(.govuk-button--secondary):not(.report-problem').click();
       cy.contains('When will the goods be imported?');
+    });
+  });
+  context('when on the UK service - SPIMM - E2E journeys', function() {
+    beforeEach('Navigates to SPIMM journey start page', () => {
+      cy.visit('/green_lanes/start/new');
+    });
+    it('Verify - Green lanes - UK to NI - Standard Category - Scenario - 1', function() {
+      const data = ['9603909100', 'BY', 'standard', 'yes']
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      cy.checkYourAnswersPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2]);
+    });
+    it.skip('Verify - Green lanes - UK to NI - Standard Category - Scenario - 2', function() {
+      const data = ['2009120090', 'UA', 'standard', 'yes', 'y170', 'y058', 'y900']
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us if your goods meet any exemptions - cat 2 and select at least one exception from each exceptions list.
+      cy.category2ExceptionsPage(data[0], data[1], data[4], data[5], data[6]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      cy.checkYourAnswersPage(data[0], data[1], true);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2]);
+    });
+    it('Verify - Green lanes - UK to NI - Standard Category - Scenario - 3', function() {
+      const data = ['1602509590', 'FO', 'standard', 'yes', 'y170', 'y058', 'y900']
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us if your goods meet any exemptions - cat 2 and select at least one exception from each exceptions list.
+      cy.category2ExceptionsPage(data[0], data[1], data[4], data[5], data[6]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      cy.checkYourAnswersPage(data[0], data[1], true);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2]);
     });
   });
 });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -19,6 +19,7 @@ import './adminCommands';
 import './dutyCommands';
 import './apiCommands';
 import './rooCommands';
+import './glCommands';
 import 'cypress-fill-command';
 require('@cypress/grep')();
 require('cypress-downloadfile/lib/downloadFileCommand');

--- a/cypress/support/glCommands.js
+++ b/cypress/support/glCommands.js
@@ -1,0 +1,131 @@
+import dayjs from 'dayjs';
+
+const dateToTrade = dayjs().format('YYYY/MM/DD');
+const todaysDate = dateToTrade.split('/');
+
+const urlContains = (commodityCode, originCountry) => `commodity_code=${commodityCode}&country_of_origin=${originCountry}&moving_date=${todaysDate[0]}-${todaysDate[1]}-${todaysDate[2]}`;
+
+// SPIMM - Simplified process for internal market movements from Great Britain to Northern Ireland.
+
+// SPIMM process start page
+Cypress.Commands.add('verifySpimmPage', () => {
+    cy.contains('Check if you are eligible for the simplified process for internal market movements');
+    cy.contains('from Great Britain to Northern Ireland (SPIMM)');
+    cy.contains('Categorisation of goods');
+    cy.contains('Before you start');
+    cy.contains('the commodity code for your goods');
+    cy.contains('the non-preferential origin of your goods');
+});
+
+Cypress.Commands.add('clkBtnToContinue', () => {
+    cy.get('[type="submit"]').click();
+});
+
+// Answer eligibility questions page
+Cypress.Commands.add('verifyEligibilityNewPage', (answer) => {
+    cy.url().should('include', '/green_lanes/eligibility/new');
+    cy.contains('Tell us about the movement of goods');
+    cy.contains('Are you moving goods from Great Britain to Northern Ireland?');
+    cy.get(`#green-lanes-eligibility-form-moving-goods-gb-to-ni-${answer}-field`).click();
+    cy.contains('Are your goods in free circulation in the UK (England, Wales, Scotland and Northern Ireland)?');
+    cy.get(`#green-lanes-eligibility-form-free-circulation-in-uk-${answer}-field`).click();
+    cy.contains('Are your goods intended to be sold to, or used by, end consumers in the UK (England, Wales, Scotland and Northern Ireland)?');
+    cy.get(`#green-lanes-eligibility-form-end-consumers-in-uk-${answer}-field`).click();
+    cy.contains('Are you authorised to trade under the UK Internal Market Scheme (UKIMS)?');
+    cy.get(`#green-lanes-eligibility-form-ukims-${answer}-field`).click();
+    cy.contains('If you need help using this tool');
+});
+
+// Check the category of your goods page
+Cypress.Commands.add('checkCategoryOfYourGoods', () => {
+    cy.url().should('include', '/green_lanes/eligibility_result/new?end_consumers_in_uk=yes&free_circulation_in_uk=yes&moving_goods_gb_to_ni=yes&ukims=yes');
+    cy.contains('Check the category of your goods');
+    cy.contains('‘not at risk’ of onward movement to the EU (opens in new tab)');
+    cy.contains('UK Internal Market Scheme (UKIMS) authorised traders (opens in new tab)');
+});
+
+// Tell us about your goods
+Cypress.Commands.add('tellUsAboutYourGoodsPage', (commodityCode, originCountry) => {
+    const movingDate = (index) => `#green_lanes_moving_requirements_form_moving_date_${index}i`;
+
+    cy.url().should('include', '/green_lanes/moving_requirements/new?commit=Continue');
+    cy.contains('Tell us about your goods');
+    // enter commodity code
+    cy.contains('What is the commodity code?');
+    cy.get('#green-lanes-moving-requirements-form-commodity-code-field').type(`${commodityCode}`);
+    cy.contains('search for a commodity (opens in a new tab).');
+    cy.contains('What is the non-preferential origin of your goods?');
+    // select origin country
+    cy.get('#green-lanes-moving-requirements-form-country-of-origin-field').select(`${originCountry}`);
+    cy.contains('find out how to determine the non-preferential origin of goods (opens in a new tab).');
+    // enter future date to continue
+    cy.contains('When is the internal movement of goods taking place?');
+    cy.get(movingDate(3)).type(`${todaysDate[2]}`);
+    cy.get(movingDate(2)).type(`${todaysDate[1]}`);
+    cy.get(movingDate(1)).type(`${todaysDate[0]}`);
+});
+
+// Tell us if your goos meet any excemptions - Category 2 exceptions
+Cypress.Commands.add('category2ExceptionsPage', (commodityCode, originCountry, documentCode1, documentCode2, documentCode3) => {
+    const documentCodes = [documentCode1, documentCode2, documentCode3]
+    const exceptionsCat2 = (documentCode) => {
+        if (documentCode == 'y900') {
+            return `#exemptions-category-assessment-818-${documentCode}-field`;
+        } else {
+            return `#exemptions-category-assessment-23-${documentCode}-field`;
+        }
+    };
+
+    cy.url().should('include',
+        `/green_lanes/applicable_exemptions/new?category=2&${urlContains(commodityCode, originCountry)}`);
+
+    cy.contains('Tell us if your goods meet any exemptions');
+    cy.contains('Your goods may be Category 2. Tell us more about your goods so that we can determine their category.');
+
+    // cy.get('#content .govuk-form-group input').then((elm) => {
+    //     console.log(elm);
+    //     cy.get(elm).check(documentCode1);
+    // });
+
+    // Select one exception from each category
+    for (var i = 0; i < documentCodes.length; i ++) {
+        cy.contains('Do your goods meet any of these Category 2 exemptions?')
+        cy.contains('View EU Regulation document');
+        cy.contains('Select all that apply');
+        cy.get(exceptionsCat2(documentCodes[i])).click();
+    }
+});
+
+// Check your answers page
+Cypress.Commands.add('checkYourAnswersPage', (commodityCode, originCountry, withExceptions) => {
+    if (withExceptions == true) {
+        const cat2Exceptions = 'ans%5B2%5D%5B23%5D%5B%5D=Y170&ans%5B2%5D%5B23%5D%5B%5D=Y058&ans%5B2%5D%5B818%5D%5B%5D=Y900&c2ex=true&category=2';
+        cy.url().should('include',
+            `/green_lanes/check_your_answers?${cat2Exceptions}&${urlContains(commodityCode, originCountry)}`);
+    } else {
+        cy.url().should('include',
+            `/green_lanes/check_your_answers?${urlContains(commodityCode, originCountry)}`);
+    }
+    cy.contains('Check your answers');
+    cy.contains('About your goods');
+    cy.get('.govuk-summary-card__content').contains(`${commodityCode}`);
+    cy.get('.govuk-summary-card__content').contains(`${originCountry}`);
+    cy.get('.govuk-summary-card__content').contains(`${todaysDate[0]}-${todaysDate[1]}-${todaysDate[2]}`);
+});
+
+// Resuls Page
+Cypress.Commands.add('verifyResultsPage', (commodityCode, originCountry, categoryResult) => {
+    cy.url().should('include', '/green_lanes/results');
+    if (`${categoryResult}` == 'standard') {
+        cy.contains('Standard Category');
+    }
+    cy.contains('Goods are eligible to move through the simplified process for internal market movements (SPIMM)');
+    cy.contains('Find out more about SPIMM');
+    cy.contains('Become an authorised trader under the UK Internal Market Scheme (UKIMS) (opens in a new tab)');
+    cy.contains('Trader Support Service (TSS) (opens in a new tab).');
+    cy.contains('About the categorisation of your goods');
+    cy.get('.govuk-summary-card__content').contains(`${commodityCode}`);
+    cy.get('.govuk-summary-card__content').contains(`${originCountry}`);
+    cy.get('.govuk-summary-card__content').contains(`${todaysDate[0]}-${todaysDate[1]}-${todaysDate[2]}`);
+    cy.contains('Check the category of other goods').click();
+});


### PR DESCRIPTION
### Jira link

- GL-958
- GL-868 (partially covered)
- GL-675


### What?

I have added/removed/altered:

- Added new smoke tests for green lanes standard category scenarios.
- Added only happy path scenarios for the standard category.
- Standard category scenario 2 throws a 'technical difficult' error so added `it.skip` for the time being to avoid running it.

### Why?

I am doing this because:

- New smoke tests will be executed as part of PR changes to ensure that the new changes don't break the existing functionality for green lanes.