### PR TITLE
added new spimm e2e journeys smoke tests for Cat1, Cat2 and Standard Category Scenarios

### DIFF
--- a/cypress/e2e/smoketests/smokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/smokeTestCI.cy.js
@@ -447,7 +447,6 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
     it('Verify - Green lanes - UK to NI - Category 1 - Scenario 2', function() {
       const data = ['8708999790', 'UA', 'Category 1', 'yes'];
       const cat1DocCodes = 'none';
-      // const cat1DocCodes = ['y792', 'y984', 'y997', 'y152'];
       // SPIMM process start page
       cy.verifySpimmPage();
       // Start now button
@@ -469,7 +468,7 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       // Continue button
       cy.clkBtnToContinue();
       // Check your answers page
-      cy.checkYourAnswersPage(data[0], data[1], true, false, false, cat1DocCodes, null, assertData[0],  assertData[1],  assertData[2]);
+      cy.checkYourAnswersPage(data[0], data[1], true, false, false, cat1DocCodes, null, assertData[0],  null,  assertData[2]);
       // Continue button
       cy.clkBtnToContinue();
       // Results Page
@@ -534,7 +533,7 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       // Results Page
       cy.verifyResultsPage(data[0], data[1], data[2], null, cat2DocCodes, null, assertData2[1], assertData2[2]);
     });
-    // Scenario 2 - Cat1 and Cat2 exemptions to check your answers to Cat 2 results page
+    // Scenario 2 - Cat1 exemptions and Cat2 'none' to check your answers to Cat 2 results page
     it('Verify - Green lanes - UK to NI - Category 2 - Scenario 3', function() {
       const data = ['6913909890', 'UA', 'Category 2', 'yes'];
       // Exception codes that need to select to get the desire result page
@@ -603,7 +602,7 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
     // Scenario 2 - Cat2 exemptions to Standard category results page
     it('Verify - Green lanes - UK to NI - Standard Category - Scenario 2', function() {
       const data = ['1602509590', 'FO', 'standard', 'yes'];
-      const cat2DocCodes = ['y058', 'y900'];
+      const cat2DocCodes = ['y170', 'y058', 'y900'];
       // SPIMM process start page
       cy.verifySpimmPage();
       // Start now button

--- a/cypress/e2e/smoketests/smokeTestCI.cy.js
+++ b/cypress/e2e/smoketests/smokeTestCI.cy.js
@@ -409,11 +409,173 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.contains('When will the goods be imported?');
     });
   });
-  context('when on the UK service - SPIMM - E2E journeys', function() {
+  context('when on the UK service - SPIMM - E2E journeys - Happy Path - Smoke Suite', function() {
+    const assertData = ['Category 1 exemptions', 'Category 2 exemptions', 'Exemption met', 
+      'Your Category 1 exemptions', 'Your Category 2 exemptions', 'Certificate needed'];
+    const assertData2 = ['Why your goods are category 1', 'Why your goods are category 2', 'Exemption not met']
     beforeEach('Navigates to SPIMM journey start page', () => {
       cy.visit('/green_lanes/start/new');
     });
-    it('Verify - Green lanes - UK to NI - Standard Category - Scenario - 1', function() {
+    // Category 1 scenarios
+    // Sceanrio 1 - Direct to check your answers to Cat1 results page
+    it('Verify - Green lanes - UK to NI - Category 1 - Scenario 1', function() {
+      const data = ['0804500089', 'KP', 'Category 1', 'yes'];
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      cy.checkYourAnswersPage(data[0], data[1], false, false, false, null, null, assertData[0],  assertData[1],  assertData[2]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2], null, null, assertData[3],  assertData[4],  assertData[5]);
+    });
+    // Sceanrio 2 - Select Cat1 exemption 'none' to get Cat1 results page
+    it('Verify - Green lanes - UK to NI - Category 1 - Scenario 2', function() {
+      const data = ['8708999790', 'UA', 'Category 1', 'yes'];
+      const cat1DocCodes = 'none';
+      // const cat1DocCodes = ['y792', 'y984', 'y997', 'y152'];
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // We need more information about your goods - cat 1 and select at least one exception from each Exemptions list.
+      cy.category1ExemptionsPage(data[0], data[1], cat1DocCodes);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      cy.checkYourAnswersPage(data[0], data[1], true, false, false, cat1DocCodes, null, assertData[0],  assertData[1],  assertData[2]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2], cat1DocCodes, null, assertData2[0],  null,  assertData2[2]);
+    });
+    // Category 2 scenarios
+    // Scenario 1 - Direct to check your answers to Cat 2 results page
+    it('Verify - Green lanes - UK to NI - Category 2 - Scenario 1', function() {
+      const data = ['7606119989', 'BY', 'Category 2', 'yes']
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      cy.checkYourAnswersPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2]);
+    });
+    // Scenario 2 - Cat2 exemptions to check your answers to Cat 2 results page
+    it('Verify - Green lanes - UK to NI - Category 2 - Scenario 2', function() {
+      const data = ['1602320000', 'GL', 'Category 2', 'yes']
+      const cat2DocCodes = 'none';
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us if your goods meet any exemptions - cat 2 and select at least one exception from each Exemptions list.
+      cy.category2ExemptionsPage(data[0], data[1], cat2DocCodes, false);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      // Only one excemption is showing in the url params instead of two or three based on user selection hence skipping this test until it is resolved.
+      cy.checkYourAnswersPage(data[0], data[1], false, true, false, null, cat2DocCodes, null, assertData[1], assertData2[2]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2], null, cat2DocCodes, null, assertData2[1], assertData2[2]);
+    });
+    // Scenario 2 - Cat1 and Cat2 exemptions to check your answers to Cat 2 results page
+    it('Verify - Green lanes - UK to NI - Category 2 - Scenario 3', function() {
+      const data = ['6913909890', 'UA', 'Category 2', 'yes'];
+      // Exception codes that need to select to get the desire result page
+      const cat1DocCodes = ['y922', 'y997', 'y984'];
+      const cat2DocCodes = 'none';
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // We need more information about your goods - cat 1 and select at least one exception from each Exemptions list.
+      cy.category1ExemptionsPage(data[0], data[1], cat1DocCodes);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us if your goods meet any exemptions - cat 2 and select at least one exception from each Exemptions list.
+      // Need to pass true and true to capture and build correct category url params values
+      cy.category2ExemptionsPage(data[0], data[1], cat2DocCodes, true);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      // Need to pass false and true to capture and build correct category url params values
+      cy.checkYourAnswersPage(data[0], data[1], false, false, true, cat1DocCodes, cat2DocCodes, assertData[0], assertData[1], assertData[2]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2], cat1DocCodes, cat2DocCodes, assertData[3], assertData2[1], null);
+    });
+    // Standard category scenarios
+    // Scenario 1 - Direct to check your answers to Standard category results page
+    it('Verify - Green lanes - UK to NI - Standard Category - Scenario 1', function() {
       const data = ['9603909100', 'BY', 'standard', 'yes']
       // SPIMM process start page
       cy.verifySpimmPage();
@@ -438,8 +600,10 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       // Results Page
       cy.verifyResultsPage(data[0], data[1], data[2]);
     });
-    it.skip('Verify - Green lanes - UK to NI - Standard Category - Scenario - 2', function() {
-      const data = ['2009120090', 'UA', 'standard', 'yes', 'y170', 'y058', 'y900']
+    // Scenario 2 - Cat2 exemptions to Standard category results page
+    it('Verify - Green lanes - UK to NI - Standard Category - Scenario 2', function() {
+      const data = ['1602509590', 'FO', 'standard', 'yes'];
+      const cat2DocCodes = ['y058', 'y900'];
       // SPIMM process start page
       cy.verifySpimmPage();
       // Start now button
@@ -456,19 +620,22 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.tellUsAboutYourGoodsPage(data[0], data[1]);
       // Continue button
       cy.clkBtnToContinue();
-      // Tell us if your goods meet any exemptions - cat 2 and select at least one exception from each exceptions list.
-      cy.category2ExceptionsPage(data[0], data[1], data[4], data[5], data[6]);
+      // Tell us if your goods meet any exemptions - cat 2 and select at least one exception from each Exemptions list.
+      // Need to pass false and true to capture and build correct category url params values
+      cy.category2ExemptionsPage(data[0], data[1], cat2DocCodes, false);
       // Continue button
       cy.clkBtnToContinue();
       // Check your answers page
-      cy.checkYourAnswersPage(data[0], data[1], true);
+      cy.checkYourAnswersPage(data[0], data[1], false, true, false, null, cat2DocCodes, null, assertData[1], assertData[2]);
       // Continue button
       cy.clkBtnToContinue();
       // Results Page
-      cy.verifyResultsPage(data[0], data[1], data[2]);
+      cy.verifyResultsPage(data[0], data[1], data[2], null, cat2DocCodes, null, assertData[4], null);
     });
-    it('Verify - Green lanes - UK to NI - Standard Category - Scenario - 3', function() {
-      const data = ['1602509590', 'FO', 'standard', 'yes', 'y170', 'y058', 'y900']
+    // Scenario 3 - Cat1 exemptions to Standard category results page
+    it('Verify - Green lanes - UK to NI - Standard Category - Scenario 3', function() {
+      const data = ['2009120090', 'UA', 'standard', 'yes'];
+      const cat1DocCodes = ['y997', 'y984'];
       // SPIMM process start page
       cy.verifySpimmPage();
       // Start now button
@@ -485,16 +652,52 @@ describe('Smoke tests to cover basic functionality', {tags: ['smokeTest']}, func
       cy.tellUsAboutYourGoodsPage(data[0], data[1]);
       // Continue button
       cy.clkBtnToContinue();
-      // Tell us if your goods meet any exemptions - cat 2 and select at least one exception from each exceptions list.
-      cy.category2ExceptionsPage(data[0], data[1], data[4], data[5], data[6]);
+      // We need more information about your goods - cat 1 and select at least one exception from each Exemptions list.
+      cy.category1ExemptionsPage(data[0], data[1], cat1DocCodes);
       // Continue button
       cy.clkBtnToContinue();
       // Check your answers page
-      cy.checkYourAnswersPage(data[0], data[1], true);
+      cy.checkYourAnswersPage(data[0], data[1], true, false, false, cat1DocCodes, null, assertData[0], null, assertData[2]);
       // Continue button
       cy.clkBtnToContinue();
       // Results Page
-      cy.verifyResultsPage(data[0], data[1], data[2]);
+      cy.verifyResultsPage(data[0], data[1], data[2], cat1DocCodes, null, assertData[3], null, null);
+    });
+    // Scenario 4 - Cat1 and Cat2 exemptions to Standard category results page
+    it('Verify - Green lanes - UK to NI - Standard Category - Scenario 4', function() {
+      const data = ['6913909890', 'UA', 'standard', 'yes'];
+      const cat1DocCodes = ['y922', 'y997', 'y984'];
+      const cat2DocCodes = ['y923'];
+      // SPIMM process start page
+      cy.verifySpimmPage();
+      // Start now button
+      cy.clkBtnToContinue();
+      // Answer eligibility questions page
+      cy.verifyEligibilityNewPage(data[3]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check the category of your goods page
+      cy.checkCategoryOfYourGoods();
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us about your goods
+      cy.tellUsAboutYourGoodsPage(data[0], data[1]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // We need more information about your goods - cat 1 and select at least one exception from each Exemptions list.
+      cy.category1ExemptionsPage(data[0], data[1], cat1DocCodes);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Tell us if your goods meet any exemptions - cat 2 and select at least one exception from each Exemptions list.
+      cy.category2ExemptionsPage(data[0], data[1], cat2DocCodes, true);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Check your answers page
+      cy.checkYourAnswersPage(data[0], data[1], false, false, true, cat1DocCodes, cat2DocCodes, assertData[0], assertData[1], assertData[2]);
+      // Continue button
+      cy.clkBtnToContinue();
+      // Results Page
+      cy.verifyResultsPage(data[0], data[1], data[2], cat1DocCodes, cat2DocCodes, assertData[3], assertData[4], null);
     });
   });
 });

--- a/cypress/support/adminCommands.js
+++ b/cypress/support/adminCommands.js
@@ -762,7 +762,3 @@ Cypress.Commands.add('removeExemption', (service) => {
   cy.contains('Exemption removed');
   cy.get('tbody').should('not.contain.value', '1');
 });
-
-
-
-

--- a/cypress/support/glCommands.js
+++ b/cypress/support/glCommands.js
@@ -129,7 +129,7 @@ Cypress.Commands.add('sortCat2ExemptionList', (documentCodes, category) => {
     let cat2UrlParams = new String();
     cy.getCategoryExemptions(documentCodes, category);
     cy.get('@cat').then(($cat2Exemptions) => {
-        onlyCat2Exemptions = Object.values($cat2Exemptions);
+        onlyCat2Exemptions = Object.values($cat2Exemptions).reverse().sort();
         for (var i = 0; i < onlyCat2Exemptions.length; i++) {
             if (!cat2UrlParams.includes(onlyCat2Exemptions[i])) {
                 cat2UrlParams += onlyCat2Exemptions[i];

--- a/cypress/support/glCommands.js
+++ b/cypress/support/glCommands.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs';
 const dateToTrade = dayjs().format('YYYY/MM/DD');
 const todaysDate = dateToTrade.split('/');
 
+// build url query param based on the number of exception documents user selected dynamically
 const urlContains = (commodityCode, originCountry) => `commodity_code=${commodityCode}&country_of_origin=${originCountry}&moving_date=${todaysDate[0]}-${todaysDate[1]}-${todaysDate[2]}`;
 
 // SPIMM - Simplified process for internal market movements from Great Britain to Northern Ireland.
@@ -46,7 +47,7 @@ Cypress.Commands.add('checkCategoryOfYourGoods', () => {
 
 // Tell us about your goods
 Cypress.Commands.add('tellUsAboutYourGoodsPage', (commodityCode, originCountry) => {
-    const movingDate = (index) => `#green_lanes_moving_requirements_form_moving_date_${index}i`;
+    const movingDate = (index) => `#green_lanes_moving_requirements_form_moving_date_${index}`;
 
     cy.url().should('include', '/green_lanes/moving_requirements/new?commit=Continue');
     cy.contains('Tell us about your goods');
@@ -65,67 +66,275 @@ Cypress.Commands.add('tellUsAboutYourGoodsPage', (commodityCode, originCountry) 
     cy.get(movingDate(1)).type(`${todaysDate[0]}`);
 });
 
-// Tell us if your goos meet any excemptions - Category 2 exceptions
-Cypress.Commands.add('category2ExceptionsPage', (commodityCode, originCountry, documentCode1, documentCode2, documentCode3) => {
-    const documentCodes = [documentCode1, documentCode2, documentCode3]
-    const exceptionsCat2 = (documentCode) => {
-        if (documentCode == 'y900') {
-            return `#exemptions-category-assessment-818-${documentCode}-field`;
-        } else {
-            return `#exemptions-category-assessment-23-${documentCode}-field`;
+// Get list of exception codes available on the exception page, compare with data and click to select that apply including 'None' exemptions.
+Cypress.Commands.add('getListOfExceptionCodesAndSelectThatApply', (documentCodes) => {
+    cy.get('#content .govuk-checkboxes input[type="checkbox"]').each(($checkbox) => {
+        for (var i = 0; i < documentCodes.length; i++) {
+            if ($checkbox.attr('id').includes(documentCodes[i])) {
+                cy.get('#'+$checkbox.attr('id')).as('checkboxes');
+                cy.get('@checkboxes').each(($checkboxElem, index) => {
+                    cy.get('#content .govuk-checkboxes').find($checkboxElem[index]).check({ multiple: true }).should('be.checked');
+                });
+            }
         }
-    };
+    });
+});
 
+// Get Exemptions list required to build url params based on exemption document codes that user selected
+Cypress.Commands.add('getCategoryExemptions', (documentCodes, category) => {
+    let captureUrlParams = new Array();
+    let caseDocCode = '';
+    cy.get('form > div > fieldset > div input').each(($checkBox) => {
+        for (var i = 0; i < documentCodes.length; i++) {
+            if ($checkBox.attr('id').includes(documentCodes[i])) {
+                const strSplit = $checkBox.attr('id').split('-');
+                if (documentCodes[i] == 'none') {
+                    caseDocCode = documentCodes[i];
+                } else {
+                    caseDocCode = documentCodes[i].toUpperCase();
+                }
+                captureUrlParams.push(`ans%5B${category}%5D%5B` + `${strSplit[3]}` + "%5D%5B%5D=" + `${caseDocCode}` + "&");
+            }
+        }
+    });
+    cy.wrap(captureUrlParams).as('cat');
+});
+
+Cypress.Commands.add('sortCat1ExemptionList', (documentCodes, category) => {
+    let onlyCat1Exemptions = new Array();
+    let cat1UrlParams = new String();
+    cy.getCategoryExemptions(documentCodes, category);
+    cy.get('@cat').then(($cat1Exemptions) => {
+        onlyCat1Exemptions = Object.values($cat1Exemptions).reverse().sort();
+        for (var i = 0; i < onlyCat1Exemptions.length; i++) {
+            if (!cat1UrlParams.includes(onlyCat1Exemptions[i])) {
+                cat1UrlParams += onlyCat1Exemptions[i];
+            }
+        }
+        cy.wrap(cat1UrlParams).as('cat1');
+    });
+});
+
+Cypress.Commands.add('sortCat2ExemptionList', (documentCodes, category) => {
+    let onlyCat2Exemptions = new Array();
+    let cat2UrlParams = new String();
+    cy.getCategoryExemptions(documentCodes, category);
+    cy.get('@cat').then(($cat2Exemptions) => {
+        onlyCat2Exemptions = Object.values($cat2Exemptions);
+        for (var i = 0; i < onlyCat2Exemptions.length; i++) {
+            if (!cat2UrlParams.includes(onlyCat2Exemptions[i])) {
+                cat2UrlParams += onlyCat2Exemptions[i];
+            }
+        }
+        cy.wrap(cat2UrlParams).as('cat2');
+    });
+});
+
+Cypress.Commands.add('getCategoriesAlias', () => {
+    const testData = {};
+    cy.get('@cat1').then((cat1) => {
+        testData.cat1 = cat1;
+    });
+    cy.get('@cat2').then((cat2) => {
+        testData.cat2 = cat2;
+    });
+    return cy.wrap(testData).as('categoriesData');
+});
+
+// We need more information about your goods
+Cypress.Commands.add('category1ExemptionsPage', (commodityCode, originCountry, documentCodes) => {
+    if (typeof(documentCodes) == 'string') {
+        documentCodes = JSON.parse("[\"" + documentCodes + "\"]");
+    }
     cy.url().should('include',
-        `/green_lanes/applicable_exemptions/new?category=2&${urlContains(commodityCode, originCountry)}`);
+        `/green_lanes/applicable_exemptions/new?category=1&${urlContains(commodityCode, originCountry)}`);
+
+    cy.contains('We need more information about your goods');
+    cy.contains('Your goods may be Category 1. Tell us more about your goods so that we can determine their category.');
+
+    // Select one exception from each category that apply
+    cy.contains('Do your goods meet any of these Category 1 exemptions?');
+    cy.contains('View EU Regulation document');
+    cy.contains('Select all that apply');
+
+    cy.getListOfExceptionCodesAndSelectThatApply(documentCodes);
+
+    // Get Exemptions list required to build url params based on exemption document codes
+    cy.sortCat1ExemptionList(documentCodes, '1');
+});
+
+// Tell us if your goos meet any excemptions - Category 2 Exemptions
+Cypress.Commands.add('category2ExemptionsPage', (commodityCode, originCountry, documentCodes, withExemptions) => {
+    if (typeof(documentCodes) == 'string') {
+        documentCodes = JSON.parse("[\"" + documentCodes + "\"]");
+    }
+    if (withExemptions == true) {
+        cy.get('@cat1').then((cat1ExemptionsUrlParams) => {
+            cy.url().should('include',
+                `/green_lanes/applicable_exemptions/new?${cat1ExemptionsUrlParams}c1ex=true&category=2&${urlContains(commodityCode, originCountry)}`);
+        });
+    } else {
+        cy.url().should('include',
+            `/green_lanes/applicable_exemptions/new?category=2&${urlContains(commodityCode, originCountry)}`);
+    }
 
     cy.contains('Tell us if your goods meet any exemptions');
     cy.contains('Your goods may be Category 2. Tell us more about your goods so that we can determine their category.');
 
-    // cy.get('#content .govuk-form-group input').then((elm) => {
-    //     console.log(elm);
-    //     cy.get(elm).check(documentCode1);
-    // });
+    // Select one exception from each category that apply
+    cy.contains('Do your goods meet any of these Category 2 exemptions?');
+    cy.contains('View EU Regulation document');
+    cy.contains('Select all that apply');
 
-    // Select one exception from each category
-    for (var i = 0; i < documentCodes.length; i ++) {
-        cy.contains('Do your goods meet any of these Category 2 exemptions?')
-        cy.contains('View EU Regulation document');
-        cy.contains('Select all that apply');
-        cy.get(exceptionsCat2(documentCodes[i])).click();
+    cy.getListOfExceptionCodesAndSelectThatApply(documentCodes);
+
+    // Get Exemptions list required to build url params for check your answers page based on exemption document codes
+    cy.sortCat2ExemptionList(documentCodes, '2');
+});
+
+Cypress.Commands.add('verifyExemptionsMet', (documentCodes, exemptMetOrCertNeed) => {
+    cy.get('.govuk-summary-card .govuk-summary-list .govuk-summary-list__row').each(($row) => {
+        if (documentCodes == 'none' || documentCodes == null) {
+            if ($row.text().includes(exemptMetOrCertNeed)) {
+                cy.contains(exemptMetOrCertNeed).should('be.visible');
+            }
+        } else {
+            for (var i = 0; i < documentCodes.length; i++) {
+                const upperCaseDocCode = documentCodes[i].toUpperCase();
+                if ($row.text().includes(upperCaseDocCode)) {
+                    cy.wrap($row.text()).should('include', upperCaseDocCode);
+                    cy.wrap($row.text()).should('include', exemptMetOrCertNeed);
+                }
+            }
+        }
+    });
+});
+
+Cypress.Commands.add('VerifyAboutGoodsAndCategorisationOfGoods', (commodityCode, originCountry, cat1DocCodes, 
+    cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed) => {
+
+    // Verify about goods table
+    cy.get('.govuk-summary-card__content').contains(`${commodityCode}`);
+    cy.get('.govuk-summary-card__content').contains(`${originCountry}`);
+    cy.get('.govuk-summary-card__content').contains(`${todaysDate[0]}-${todaysDate[1]}-${todaysDate[2]}`);
+
+    // Verify exemptions have met category section on the results page
+    let documentCodes;
+    if (typeof(cat1DocCodes) == 'string' && typeof(cat2DocCodes) == 'string') {
+        cy.get('.govuk-summary-card__title-wrapper h2').should('not.contain', cat1ExemptOrHaveMet);
+        cy.get('.govuk-summary-card__title-wrapper h2').should('not.contain', cat2ExemptOrHaveMet);
+        cy.should('not.contain', exemptMetOrCertNeed);
+    } else if (cat1DocCodes != null && cat2DocCodes != null) {
+        documentCodes = cat1DocCodes.concat(cat2DocCodes);
+        cy.get('.govuk-summary-card__title-wrapper h2').contains(cat1ExemptOrHaveMet);
+        cy.get('.govuk-summary-card__title-wrapper h2').contains(cat2ExemptOrHaveMet);
+    } else if (cat1DocCodes != null || cat1DocCodes == 'none') {
+        documentCodes = cat1DocCodes;
+        cy.get('.govuk-summary-card__title-wrapper h2').contains(cat1ExemptOrHaveMet);
+    } else if (cat2DocCodes != null || cat2DocCodes == 'none') {
+        documentCodes = cat2DocCodes;
+        cy.get('.govuk-summary-card__title-wrapper h2').contains(cat2ExemptOrHaveMet);
+        
+    } else {
+        cy.get('.govuk-summary-card__title-wrapper h2').should('not.contain', cat1ExemptOrHaveMet);
+        cy.get('.govuk-summary-card__title-wrapper h2').should('not.contain', cat2ExemptOrHaveMet);
+        cy.should('not.contain', exemptMetOrCertNeed);
+    }
+    if (exemptMetOrCertNeed != null) {
+        cy.verifyExemptionsMet(documentCodes, exemptMetOrCertNeed);
     }
 });
 
 // Check your answers page
-Cypress.Commands.add('checkYourAnswersPage', (commodityCode, originCountry, withExceptions) => {
-    if (withExceptions == true) {
-        const cat2Exceptions = 'ans%5B2%5D%5B23%5D%5B%5D=Y170&ans%5B2%5D%5B23%5D%5B%5D=Y058&ans%5B2%5D%5B818%5D%5B%5D=Y900&c2ex=true&category=2';
-        cy.url().should('include',
-            `/green_lanes/check_your_answers?${cat2Exceptions}&${urlContains(commodityCode, originCountry)}`);
+Cypress.Commands.add('checkYourAnswersPage', 
+    (commodityCode, originCountry, onlyCat1Exemptions, onlyCat2Exemptions, withExemptions,
+        cat1DocCodes, cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed) => {
+    let c1exValue; let c2exValue;
+    if (onlyCat2Exemptions == true) {
+        if (cat2DocCodes != 'none' || cat2DocCodes == 'none') {
+            if (cat2DocCodes != 'none') {
+                c2exValue = true;
+            }
+            else {
+                c2exValue = false;
+            }
+            cy.log('c2exValue', c2exValue);
+            cy.get('@cat2').then((cat2ExemptionsUrlParams) => {
+                cy.url().should('include',
+                    `/green_lanes/check_your_answers?${cat2ExemptionsUrlParams}c2ex=${c2exValue}&category=2&${urlContains(commodityCode, originCountry)}`); 
+            });
+        } else {
+            cy.url().should('include',
+                `/green_lanes/check_your_answers?&c2ex=true&category=2&${urlContains(commodityCode, originCountry)}`);
+        }
+    } else if (onlyCat1Exemptions == true) {
+        if (cat1DocCodes != 'none') {
+            c1exValue = true;
+        }
+        else {
+            c1exValue = false;
+        }
+        cy.get('@cat1').then((cat1ExemptionsUrlParams) => {
+            cy.url().should('include',
+                `/green_lanes/check_your_answers?${cat1ExemptionsUrlParams}c1ex=${c1exValue}&category=1&${urlContains(commodityCode, originCountry)}`);
+        });
+    } else if (withExemptions == true) {
+        if (cat2DocCodes != 'none') {
+            c1exValue= true, c2exValue = true;
+        }
+        else {
+            c1exValue= true, c2exValue = false;
+        }
+        cy.getCategoriesAlias();
+        cy.get('@categoriesData').then((categoriesDataDict) => {
+            let categoriesData = Object.values(categoriesDataDict).toString();
+            categoriesData = categoriesData.replace(',', '');
+            cy.url().should('include',
+                `/green_lanes/check_your_answers?${categoriesData}c1ex=${c1exValue}&c2ex=${c2exValue}&category=2&${urlContains(commodityCode, originCountry)}`);
+        });
     } else {
         cy.url().should('include',
             `/green_lanes/check_your_answers?${urlContains(commodityCode, originCountry)}`);
     }
-    cy.contains('Check your answers');
-    cy.contains('About your goods');
-    cy.get('.govuk-summary-card__content').contains(`${commodityCode}`);
-    cy.get('.govuk-summary-card__content').contains(`${originCountry}`);
-    cy.get('.govuk-summary-card__content').contains(`${todaysDate[0]}-${todaysDate[1]}-${todaysDate[2]}`);
+
+    // Verify the check your answers table
+    cy.get('.govuk-heading-l').contains('Check your answers');
+    cy.get('.govuk-summary-card__title-wrapper h2').contains('About your goods');
+
+    // Verify Categories exemptions met
+    cy.VerifyAboutGoodsAndCategorisationOfGoods(commodityCode, originCountry, cat1DocCodes,
+        cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed);
 });
 
-// Resuls Page
-Cypress.Commands.add('verifyResultsPage', (commodityCode, originCountry, categoryResult) => {
+// Results Page
+Cypress.Commands.add('verifyResultsPage', (commodityCode, originCountry, categoryResult, cat1DocCodes, cat2DocCodes,
+    cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed) => {
     cy.url().should('include', '/green_lanes/results');
     if (`${categoryResult}` == 'standard') {
         cy.contains('Standard Category');
+    } else if (`${categoryResult}` == 'Category 2') {
+        cy.contains('Category 2');
+    } else if (`${categoryResult}` == 'Category 1') {
+        cy.contains('Category 1');
+        cy.contains('Goods are not eligible to move through the simplified process for internal market movements (SPIMM)');
     }
-    cy.contains('Goods are eligible to move through the simplified process for internal market movements (SPIMM)');
+    if (`${categoryResult}` == 'Category 2' || `${categoryResult}` == 'standard') {
+        cy.contains('Goods are eligible to move through the simplified process for internal market movements (SPIMM)');
+    }
     cy.contains('Find out more about SPIMM');
-    cy.contains('Become an authorised trader under the UK Internal Market Scheme (UKIMS) (opens in a new tab)');
-    cy.contains('Trader Support Service (TSS) (opens in a new tab).');
+    cy.contains('What you should do next');
+    if (`${categoryResult}` == 'Category 1') {
+        cy.contains('Category 1 goods cannot continue through SPIMM.');
+        cy.contains('Find out more about trading and moving goods in and out of Northern Ireland (opens in a new tab)');
+    } else {
+        cy.contains('Become an authorised trader under the UK Internal Market Scheme (UKIMS) (opens in a new tab)');
+        cy.contains('Trader Support Service (TSS) (opens in a new tab).');
+    }
     cy.contains('About the categorisation of your goods');
-    cy.get('.govuk-summary-card__content').contains(`${commodityCode}`);
-    cy.get('.govuk-summary-card__content').contains(`${originCountry}`);
-    cy.get('.govuk-summary-card__content').contains(`${todaysDate[0]}-${todaysDate[1]}-${todaysDate[2]}`);
+
+    // Verify Categories exemptions have met and Certification needed
+    cy.VerifyAboutGoodsAndCategorisationOfGoods(commodityCode, originCountry, cat1DocCodes,
+        cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed);
+    
     cy.contains('Check the category of other goods').click();
 });

--- a/cypress/support/glCommands.js
+++ b/cypress/support/glCommands.js
@@ -10,12 +10,14 @@ const urlContains = (commodityCode, originCountry) => `commodity_code=${commodit
 
 // SPIMM process start page
 Cypress.Commands.add('verifySpimmPage', () => {
-    cy.contains('Check if you are eligible for the simplified process for internal market movements');
-    cy.contains('from Great Britain to Northern Ireland (SPIMM)');
+    cy.contains('Check if you are eligible for the simplified process for internal market movements') +
+        ('from Great Britain to Northern Ireland (SPIMM)');
     cy.contains('Categorisation of goods');
     cy.contains('Before you start');
     cy.contains('the commodity code for your goods');
+    cy.get('.govuk-list > li:nth-child(1) > a').should('have.attr', 'href', 'https://www.trade-tariff.service.gov.uk/find_commodity');
     cy.contains('the non-preferential origin of your goods');
+    cy.get('.govuk-list > li:nth-child(2) > a').should('have.attr', 'href', 'https://www.trade-tariff.service.gov.uk/howto/origin');
 });
 
 Cypress.Commands.add('clkBtnToContinue', () => {
@@ -42,7 +44,11 @@ Cypress.Commands.add('checkCategoryOfYourGoods', () => {
     cy.url().should('include', '/green_lanes/eligibility_result/new?end_consumers_in_uk=yes&free_circulation_in_uk=yes&moving_goods_gb_to_ni=yes&ukims=yes');
     cy.contains('Check the category of your goods');
     cy.contains('‘not at risk’ of onward movement to the EU (opens in new tab)');
+    cy.get('.govuk-grid-column-two-thirds > p:nth-child(2) > a').should('have.attr', 'href',) +
+        ('https://www.gov.uk/guidance/check-if-you-can-declare-goods-you-bring-into-northern-ireland-not-at-risk-of-moving-to-the-eu');
     cy.contains('UK Internal Market Scheme (UKIMS) authorised traders (opens in new tab)');
+    cy.get('.govuk-grid-column-two-thirds > p:nth-child(3)> a').should('have.attr', 'href',) +
+        ('https://www.gov.uk/guidance/apply-for-authorisation-for-the-uk-internal-market-scheme-if-you-bring-goods-into-northern-ireland');
 });
 
 // Tell us about your goods
@@ -55,10 +61,13 @@ Cypress.Commands.add('tellUsAboutYourGoodsPage', (commodityCode, originCountry) 
     cy.contains('What is the commodity code?');
     cy.get('#green-lanes-moving-requirements-form-commodity-code-field').type(`${commodityCode}`);
     cy.contains('search for a commodity (opens in a new tab).');
+    cy.get('.new_green_lanes_moving_requirements_form > div:nth-child(3) > div >a').should('have.attr', 'href', 'https://www.gov.uk/trade-tariff');
     cy.contains('What is the non-preferential origin of your goods?');
     // select origin country
     cy.get('#green-lanes-moving-requirements-form-country-of-origin-field').select(`${originCountry}`);
     cy.contains('find out how to determine the non-preferential origin of goods (opens in a new tab).');
+    cy.get('.new_green_lanes_moving_requirements_form > div:nth-child(4) > div >a').should('have.attr', 'href',) +
+        ('https://www.trade-tariff.service.gov.uk/howto/origin');
     // enter future date to continue
     cy.contains('When is the internal movement of goods taking place?');
     cy.get(movingDate(3)).type(`${todaysDate[2]}`);
@@ -71,7 +80,7 @@ Cypress.Commands.add('getListOfExceptionCodesAndSelectThatApply', (documentCodes
     cy.get('#content .govuk-checkboxes input[type="checkbox"]').each(($checkbox) => {
         for (var i = 0; i < documentCodes.length; i++) {
             if ($checkbox.attr('id').includes(documentCodes[i])) {
-                cy.get('#'+$checkbox.attr('id')).as('checkboxes');
+                cy.get('#' + $checkbox.attr('id')).as('checkboxes');
                 cy.get('@checkboxes').each(($checkboxElem, index) => {
                     cy.get('#content .govuk-checkboxes').find($checkboxElem[index]).check({ multiple: true }).should('be.checked');
                 });
@@ -143,7 +152,7 @@ Cypress.Commands.add('getCategoriesAlias', () => {
 
 // We need more information about your goods
 Cypress.Commands.add('category1ExemptionsPage', (commodityCode, originCountry, documentCodes) => {
-    if (typeof(documentCodes) == 'string') {
+    if (typeof (documentCodes) == 'string') {
         documentCodes = JSON.parse("[\"" + documentCodes + "\"]");
     }
     cy.url().should('include',
@@ -165,7 +174,7 @@ Cypress.Commands.add('category1ExemptionsPage', (commodityCode, originCountry, d
 
 // Tell us if your goos meet any excemptions - Category 2 Exemptions
 Cypress.Commands.add('category2ExemptionsPage', (commodityCode, originCountry, documentCodes, withExemptions) => {
-    if (typeof(documentCodes) == 'string') {
+    if (typeof (documentCodes) == 'string') {
         documentCodes = JSON.parse("[\"" + documentCodes + "\"]");
     }
     if (withExemptions == true) {
@@ -210,7 +219,7 @@ Cypress.Commands.add('verifyExemptionsMet', (documentCodes, exemptMetOrCertNeed)
     });
 });
 
-Cypress.Commands.add('VerifyAboutGoodsAndCategorisationOfGoods', (commodityCode, originCountry, cat1DocCodes, 
+Cypress.Commands.add('VerifyAboutGoodsAndCategorisationOfGoods', (commodityCode, originCountry, cat1DocCodes,
     cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed) => {
 
     // Verify about goods table
@@ -220,7 +229,7 @@ Cypress.Commands.add('VerifyAboutGoodsAndCategorisationOfGoods', (commodityCode,
 
     // Verify exemptions have met category section on the results page
     let documentCodes;
-    if (typeof(cat1DocCodes) == 'string' && typeof(cat2DocCodes) == 'string') {
+    if (typeof (cat1DocCodes) == 'string' && typeof (cat2DocCodes) == 'string') {
         cy.get('.govuk-summary-card__title-wrapper h2').should('not.contain', cat1ExemptOrHaveMet);
         cy.get('.govuk-summary-card__title-wrapper h2').should('not.contain', cat2ExemptOrHaveMet);
         cy.should('not.contain', exemptMetOrCertNeed);
@@ -234,7 +243,7 @@ Cypress.Commands.add('VerifyAboutGoodsAndCategorisationOfGoods', (commodityCode,
     } else if (cat2DocCodes != null || cat2DocCodes == 'none') {
         documentCodes = cat2DocCodes;
         cy.get('.govuk-summary-card__title-wrapper h2').contains(cat2ExemptOrHaveMet);
-        
+
     } else {
         cy.get('.govuk-summary-card__title-wrapper h2').should('not.contain', cat1ExemptOrHaveMet);
         cy.get('.govuk-summary-card__title-wrapper h2').should('not.contain', cat2ExemptOrHaveMet);
@@ -246,65 +255,65 @@ Cypress.Commands.add('VerifyAboutGoodsAndCategorisationOfGoods', (commodityCode,
 });
 
 // Check your answers page
-Cypress.Commands.add('checkYourAnswersPage', 
+Cypress.Commands.add('checkYourAnswersPage',
     (commodityCode, originCountry, onlyCat1Exemptions, onlyCat2Exemptions, withExemptions,
         cat1DocCodes, cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed) => {
-    let c1exValue; let c2exValue;
-    if (onlyCat2Exemptions == true) {
-        if (cat2DocCodes != 'none' || cat2DocCodes == 'none') {
-            if (cat2DocCodes != 'none') {
-                c2exValue = true;
+        let c1exValue; let c2exValue;
+        if (onlyCat2Exemptions == true) {
+            if (cat2DocCodes != 'none' || cat2DocCodes == 'none') {
+                if (cat2DocCodes != 'none') {
+                    c2exValue = true;
+                }
+                else {
+                    c2exValue = false;
+                }
+                cy.log('c2exValue', c2exValue);
+                cy.get('@cat2').then((cat2ExemptionsUrlParams) => {
+                    cy.url().should('include',
+                        `/green_lanes/check_your_answers?${cat2ExemptionsUrlParams}c2ex=${c2exValue}&category=2&${urlContains(commodityCode, originCountry)}`);
+                });
+            } else {
+                cy.url().should('include',
+                    `/green_lanes/check_your_answers?&c2ex=true&category=2&${urlContains(commodityCode, originCountry)}`);
+            }
+        } else if (onlyCat1Exemptions == true) {
+            if (cat1DocCodes != 'none') {
+                c1exValue = true;
             }
             else {
-                c2exValue = false;
+                c1exValue = false;
             }
-            cy.log('c2exValue', c2exValue);
-            cy.get('@cat2').then((cat2ExemptionsUrlParams) => {
+            cy.get('@cat1').then((cat1ExemptionsUrlParams) => {
                 cy.url().should('include',
-                    `/green_lanes/check_your_answers?${cat2ExemptionsUrlParams}c2ex=${c2exValue}&category=2&${urlContains(commodityCode, originCountry)}`); 
+                    `/green_lanes/check_your_answers?${cat1ExemptionsUrlParams}c1ex=${c1exValue}&category=1&${urlContains(commodityCode, originCountry)}`);
+            });
+        } else if (withExemptions == true) {
+            if (cat2DocCodes != 'none') {
+                c1exValue = true, c2exValue = true;
+            }
+            else {
+                c1exValue = true, c2exValue = false;
+            }
+            cy.getCategoriesAlias();
+            cy.get('@categoriesData').then((categoriesDataDict) => {
+                let categoriesData = Object.values(categoriesDataDict).toString();
+                categoriesData = categoriesData.replace(',', '');
+                cy.url().should('include',
+                    `/green_lanes/check_your_answers?${categoriesData}c1ex=${c1exValue}&c2ex=${c2exValue}&category=2&${urlContains(commodityCode, originCountry)}`);
             });
         } else {
             cy.url().should('include',
-                `/green_lanes/check_your_answers?&c2ex=true&category=2&${urlContains(commodityCode, originCountry)}`);
+                `/green_lanes/check_your_answers?${urlContains(commodityCode, originCountry)}`);
         }
-    } else if (onlyCat1Exemptions == true) {
-        if (cat1DocCodes != 'none') {
-            c1exValue = true;
-        }
-        else {
-            c1exValue = false;
-        }
-        cy.get('@cat1').then((cat1ExemptionsUrlParams) => {
-            cy.url().should('include',
-                `/green_lanes/check_your_answers?${cat1ExemptionsUrlParams}c1ex=${c1exValue}&category=1&${urlContains(commodityCode, originCountry)}`);
-        });
-    } else if (withExemptions == true) {
-        if (cat2DocCodes != 'none') {
-            c1exValue= true, c2exValue = true;
-        }
-        else {
-            c1exValue= true, c2exValue = false;
-        }
-        cy.getCategoriesAlias();
-        cy.get('@categoriesData').then((categoriesDataDict) => {
-            let categoriesData = Object.values(categoriesDataDict).toString();
-            categoriesData = categoriesData.replace(',', '');
-            cy.url().should('include',
-                `/green_lanes/check_your_answers?${categoriesData}c1ex=${c1exValue}&c2ex=${c2exValue}&category=2&${urlContains(commodityCode, originCountry)}`);
-        });
-    } else {
-        cy.url().should('include',
-            `/green_lanes/check_your_answers?${urlContains(commodityCode, originCountry)}`);
-    }
 
-    // Verify the check your answers table
-    cy.get('.govuk-heading-l').contains('Check your answers');
-    cy.get('.govuk-summary-card__title-wrapper h2').contains('About your goods');
+        // Verify the check your answers table
+        cy.get('.govuk-heading-l').contains('Check your answers');
+        cy.get('.govuk-summary-card__title-wrapper h2').contains('About your goods');
 
-    // Verify Categories exemptions met
-    cy.VerifyAboutGoodsAndCategorisationOfGoods(commodityCode, originCountry, cat1DocCodes,
-        cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed);
-});
+        // Verify Categories exemptions met
+        cy.VerifyAboutGoodsAndCategorisationOfGoods(commodityCode, originCountry, cat1DocCodes,
+            cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed);
+    });
 
 // Results Page
 Cypress.Commands.add('verifyResultsPage', (commodityCode, originCountry, categoryResult, cat1DocCodes, cat2DocCodes,
@@ -322,10 +331,16 @@ Cypress.Commands.add('verifyResultsPage', (commodityCode, originCountry, categor
         cy.contains('Goods are eligible to move through the simplified process for internal market movements (SPIMM)');
     }
     cy.contains('Find out more about SPIMM');
+    cy.get('.tariff > #content > p:nth-child(5) > a').should('have.attr', 'href',) +
+        ('https://www.figma.com/proto/k0Vb4ZCE5gjcsevbke0R6Q/Online-Tariff-Tool-%2F-GL?page-id=8705%3A50327&node-id=8677-13921&') +
+        ('viewport=833%2C310%2C0.47&t=MoxrxfJbs0nHWIt5-1&scaling=min-zoom&content-scaling=fixed')
     cy.contains('What you should do next');
     if (`${categoryResult}` == 'Category 1') {
         cy.contains('Category 1 goods cannot continue through SPIMM.');
         cy.contains('Find out more about trading and moving goods in and out of Northern Ireland (opens in a new tab)');
+        cy.get('.tariff > #content > p:nth-child(9) > a').should('have.attr', 'href',) +
+            ('https://www.gov.uk/guidance/trading-and-moving-goods-in-and-out-of-northern-ireland');
+
     } else {
         cy.contains('Become an authorised trader under the UK Internal Market Scheme (UKIMS) (opens in a new tab)');
         cy.contains('Trader Support Service (TSS) (opens in a new tab).');
@@ -335,6 +350,6 @@ Cypress.Commands.add('verifyResultsPage', (commodityCode, originCountry, categor
     // Verify Categories exemptions have met and Certification needed
     cy.VerifyAboutGoodsAndCategorisationOfGoods(commodityCode, originCountry, cat1DocCodes,
         cat2DocCodes, cat1ExemptOrHaveMet, cat2ExemptOrHaveMet, exemptMetOrCertNeed);
-    
+
     cy.contains('Check the category of other goods').click();
 });


### PR DESCRIPTION
### Jira link

- GL-868
- GL-531
- GL-675
- GL-650
- GL-645
- GL-673
- GL-674
- GL-638
- GL-753

### What?

I have added/removed/altered:

- Added new smoke tests (happy path) SPIMM E2E journeys for Cat1, Cat2 scenarios
- Updated smoke tests (happy path) SPIMM E2E journeys for Standard category scenarios

### Why?

I am doing this because:

- To ensure that we have coverage for SPIMM E2E journeys as part of our build smoke suite execution whenever we push code changes to run those tests to validate that the new changes don't break any existing functionality.

