### PR TITLE
OTT-275: Adjust import date validation check to reflect new default

### DIFF
--- a/cypress/e2e/DutyCalculator/dcShared/dcImportDate.cy.js
+++ b/cypress/e2e/DutyCalculator/dcShared/dcImportDate.cy.js
@@ -62,6 +62,12 @@ describe('🧮 📅 | dcImportDate | Duty Calculator main page |', function () {
     it(`📅 No Date ${country[i]}`, function () {
       cy.visit(`duty-calculator/${country[i]}/0702000007/import-date`);
       cy.contains(`${pagetitles[i]}`);
+      cy.get('input[name=\'steps_import_date[import_date(3i)]\']').click();
+      cy.get('input[name=\'steps_import_date[import_date(3i)]\']').clear();
+      cy.get('input[name=\'steps_import_date[import_date(2i)]\']').click();
+      cy.get('input[name=\'steps_import_date[import_date(2i)]\']').clear();
+      cy.get('input[name=\'steps_import_date[import_date(1i)]\']').click();
+      cy.get('input[name=\'steps_import_date[import_date(1i)]\']').clear();
       cy.contains('Continue').click();
       cy.get('.govuk-error-summary');
       cy.contains('There is a problem');


### PR DESCRIPTION
### Jira link

OTT-275

Today's date is automatically populated for a fresh duty calculator session:

![image](https://github.com/user-attachments/assets/c679aa17-35d4-4fc1-893e-8ce2b7e8ce84)


### What?

I have added/removed/altered:

- [x] Added handling for default import date in verification of validation messages

### Why?

I am doing this because:

- This change enabled us to pass dates from the frontend to the backend to make sure commodities were still visible
